### PR TITLE
Do not allow implicit casting of `USE_SAFE_SINGLETON_FACTORY` variable, add celo config

### DIFF
--- a/allowances/migrations/1_deploy_allowance_modules.js
+++ b/allowances/migrations/1_deploy_allowance_modules.js
@@ -1,13 +1,13 @@
-const { deployTruffleContract } = require('@gnosis.pm/singleton-deployer-truffle');
-const AllowanceModule = artifacts.require("AllowanceModule");
+const { deployTruffleContract } = require("@gnosis.pm/singleton-deployer-truffle")
+const AllowanceModule = artifacts.require("AllowanceModule")
 
 // Safe singleton factory was deployed using eip155 transaction
 // If the network enforces EIP155, then the safe singleton factory should be used
 // More at https://github.com/gnosis/safe-singleton-factory
-const USE_SAFE_SINGLETON_FACTORY = process.env.USE_SAFE_SINGLETON_FACTORY;
+const USE_SAFE_SINGLETON_FACTORY = process.env.USE_SAFE_SINGLETON_FACTORY === "true"
 
-module.exports = function(deployer) {
+module.exports = function (deployer) {
   deployer.then(async () => {
-    await deployTruffleContract(web3, AllowanceModule, USE_SAFE_SINGLETON_FACTORY);
+    await deployTruffleContract(web3, AllowanceModule, USE_SAFE_SINGLETON_FACTORY)
   })
-};
+}

--- a/allowances/truffle-config.js
+++ b/allowances/truffle-config.js
@@ -80,7 +80,14 @@ module.exports = {
       },
       network_id: '137',
       gasPrice: 35000000000, // 35 Gwei
-    }
+    },
+    celo: {
+      network_id: 42220,
+      provider: () => {
+        return new HDWalletProvider(mnemonic, 'https://1rpc.io/celo')
+      },
+      gasPrice: 15000000000, // 15 Gwei
+    },
   },
   compilers: {
     solc: {


### PR DESCRIPTION
This PR:
- fixes a bug where any string set as `USE_SAFE_SINGLETON_FACTORY` would eval as a truthy value
- add configuration for celo network