### PR TITLE
ERC4337 module feature: Extract execution to a separate function and require success in the internal call

### DIFF
--- a/4337/.env.sample
+++ b/4337/.env.sample
@@ -7,11 +7,18 @@ ETHERSCAN_API_KEY=""
 
 # Mnemonic to use in the test script
 SCRIPT_MNEMONIC=""
-# Safe to use in the user op test script
-SCRIPT_SAFE_ADDRESS=
 # Enable debug in the test script
 SCRIPT_DEBUG=true
 # Bundler to use in the user op test script
 SCRIPT_BUNDLER_URL=""
 # Module to use in the user op test script
 SCRIPT_MODULE_ADDRESS=
+# Library to add modules in the user op test script
+SCRIPT_ADD_MODULES_LIB_ADDRESS=""
+# Proxy factory to use in the user op test script
+SCRIPT_PROXY_FACTORY_ADDRESS=
+# Singleton address to use in the user op test script
+SCRIPT_SAFE_SINGLETON_ADDRESS=
+
+# Entrypoint address to use for the module deployment
+DEPLOY_ENTRY_POINT=""

--- a/4337/contracts/EIP4337Module.sol
+++ b/4337/contracts/EIP4337Module.sol
@@ -7,7 +7,6 @@ import {UserOperation, UserOperationLib} from "./UserOperation.sol";
 import {INonceManager} from "./interfaces/ERC4337.sol";
 import {ISafe} from "./interfaces/Safe.sol";
 
-
 /// @title EIP4337Module
 contract Simple4337Module is HandlerContext, CompatibilityFallbackHandler {
     using UserOperationLib for UserOperation;
@@ -170,5 +169,3 @@ contract Simple4337Module is HandlerContext, CompatibilityFallbackHandler {
         }
     }
 }
-
-

--- a/4337/contracts/interfaces/Safe.sol
+++ b/4337/contracts/interfaces/Safe.sol
@@ -25,6 +25,22 @@ interface ISafe {
     ) external returns (bool success);
 
     /**
+     * @notice Execute `operation` (0: Call, 1: DelegateCall) to `to` with `value` (Native Token) and return data
+     * @param to Destination address of module transaction.
+     * @param value Ether value of module transaction.
+     * @param data Data payload of module transaction.
+     * @param operation Operation type of module transaction.
+     * @return success Boolean flag indicating if the call succeeded.
+     * @return returnData Data returned by the call.
+     */
+    function execTransactionFromModuleReturnData(
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint8 operation
+    ) external returns (bool success, bytes memory returnData);
+
+    /**
      * @dev Checks whether the signature provided is valid for the provided data, hash. Will revert otherwise.
      * @param dataHash Hash of the data (could be either a message hash or transaction hash)
      * @param data That should be signed (this is passed to an external validator contract)

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -128,7 +128,7 @@ contract Safe4337Mock is SafeMock {
     bytes4 public immutable expectedExecutionFunctionId;
 
     constructor(address entryPoint) SafeMock(entryPoint) {
-        expectedExecutionFunctionId = bytes4(keccak256("execTransactionFromModule(address,uint256,bytes,uint8)"));
+        expectedExecutionFunctionId = bytes4(keccak256("executeUserOp(bytes)"));
     }
 
     /// @dev Validates user operation provided by the entry point
@@ -154,6 +154,24 @@ contract Safe4337Mock is SafeMock {
             entryPoint.call{value: requiredPrefund}("");
         }
         return 0;
+    }
+
+    /// @notice Executes user operation provided by the entry point
+    /// @dev Reverts if unsuccessful
+    /// @param executionData Execution data. Expects it to be a call to the `execTransactionFromModule` function of the Safe.
+    ///                      Validated in the `validateUserOp` function.
+    function executeUserOp(bytes calldata executionData) external {
+        address entryPoint = msg.sender;
+        require(entryPoint == supportedEntryPoint, "Unsupported entry point");
+
+        // [4:] slice is needed to remove the function selector, abi.decode will not work with it because
+        // it is not 32 bytes
+        (address to, uint256 value, bytes memory data, uint8 operation) = abi.decode(executionData[4:], (address, uint256, bytes, uint8));
+
+        bool success;
+        if (operation == 1) (success, ) = to.delegatecall(data);
+        else (success, ) = to.call{value: value}(data);
+        require(success, "Execution failed");
     }
 
     function domainSeparator() public view returns (bytes32) {

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -128,7 +128,7 @@ contract Safe4337Mock is SafeMock {
     bytes4 public immutable expectedExecutionFunctionId;
 
     constructor(address entryPoint) SafeMock(entryPoint) {
-        expectedExecutionFunctionId = bytes4(keccak256("executeUserOp(bytes)"));
+        expectedExecutionFunctionId = bytes4(keccak256("executeUserOp(address,uint256,bytes,uint8)"));
     }
 
     /// @dev Validates user operation provided by the entry point
@@ -158,15 +158,18 @@ contract Safe4337Mock is SafeMock {
 
     /// @notice Executes user operation provided by the entry point
     /// @dev Reverts if unsuccessful
-    /// @param executionData Execution data. Expects it to be a call to the `execTransactionFromModule` function of the Safe.
-    ///                      Validated in the `validateUserOp` function.
-    function executeUserOp(bytes calldata executionData) external {
+    /// @param to Destination address of the user operation.
+    /// @param value Ether value of the user operation.
+    /// @param data Data payload of the user operation.
+    /// @param operation Operation type of the user operation.
+    function executeUserOp(
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint8 operation
+    ) external {
         address entryPoint = msg.sender;
         require(entryPoint == supportedEntryPoint, "Unsupported entry point");
-
-        // [4:] slice is needed to remove the function selector, abi.decode will not work with it because
-        // it is not 32 bytes
-        (address to, uint256 value, bytes memory data, uint8 operation) = abi.decode(executionData[4:], (address, uint256, bytes, uint8));
 
         bool success;
         if (operation == 1) (success, ) = to.delegatecall(data);

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -73,6 +73,18 @@ contract SafeMock {
         else (success, ) = to.call{value: value}(data);
     }
 
+    function execTransactionFromModuleReturnData(
+        address payable to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation
+    ) external returns (bool success, bytes memory returnData) {
+        require(modules[msg.sender], "not executing that");
+
+        if (operation == 1) (success, returnData) = to.delegatecall(data);
+        else (success, returnData) = to.call{value: value}(data);
+    }
+
     /**
      * @dev Reads `length` bytes of storage in the currents contract
      * @param offset - the offset in the current contract's storage in words to start reading from
@@ -125,11 +137,7 @@ contract Safe4337Mock is SafeMock {
             "SafeOp(address safe,bytes callData,uint256 nonce,uint256 preVerificationGas,uint256 verificationGasLimit,uint256 callGasLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,address entryPoint)"
         );
 
-    bytes4 public immutable expectedExecutionFunctionId;
-
-    constructor(address entryPoint) SafeMock(entryPoint) {
-        expectedExecutionFunctionId = bytes4(keccak256("executeUserOp(address,uint256,bytes,uint8)"));
-    }
+    constructor(address entryPoint) SafeMock(entryPoint) {}
 
     /// @dev Validates user operation provided by the entry point
     /// @param userOp User operation struct
@@ -144,7 +152,12 @@ contract Safe4337Mock is SafeMock {
 
         validateReplayProtection(userOp);
 
-        require(expectedExecutionFunctionId == bytes4(userOp.callData), "Unsupported execution function id");
+        // We check the execution function signature to make sure the entryPoint can't call any other function
+        // and make sure the execution of the user operation is handled by the module
+        require(
+            this.executeUserOp.selector == bytes4(userOp.callData) || this.executeUserOpWithErrorString.selector == bytes4(userOp.callData),
+            "Unsupported execution function id"
+        );
 
         // We need to make sure that the entryPoint's requested prefund is in bounds
         require(requiredPrefund <= userOp.requiredPreFund(), "Prefund too high");
@@ -175,6 +188,28 @@ contract Safe4337Mock is SafeMock {
         if (operation == 1) (success, ) = to.delegatecall(data);
         else (success, ) = to.call{value: value}(data);
         require(success, "Execution failed");
+    }
+
+    /// @notice Executes user operation provided by the entry point
+    /// @dev Reverts if unsuccessful and bubbles up the error message
+    /// @param to Destination address of the user operation.
+    /// @param value Ether value of the user operation.
+    /// @param data Data payload of the user operation.
+    /// @param operation Operation type of the user operation.
+    function executeUserOpWithErrorString(
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint8 operation
+    ) external {
+        address entryPoint = msg.sender;
+        require(entryPoint == supportedEntryPoint, "Unsupported entry point");
+
+        bool success;
+        bytes memory returnData;
+        if (operation == 1) (success, returnData) = to.delegatecall(data);
+        else (success, returnData) = to.call{value: value}(data);
+        require(success, string(returnData));
     }
 
     function domainSeparator() public view returns (bytes32) {

--- a/4337/contracts/test/TestEntryPoint.sol
+++ b/4337/contracts/test/TestEntryPoint.sol
@@ -44,8 +44,6 @@ contract TestEntryPoint is INonceManager {
     mapping(address => uint256) balances;
     mapping(address => mapping(uint192 => uint256)) public nonceSequenceNumber;
 
-    uint256 private constant REVERT_REASON_MAX_LEN = 2048;
-
     constructor() {
         senderCreator = new SenderCreator();
     }
@@ -82,20 +80,6 @@ contract TestEntryPoint is INonceManager {
         (bool success, bytes memory returnData) = userOp.sender.call{gas: userOp.callGasLimit}(userOp.callData);
         if (!success) {
             emit UserOpReverted(returnData);
-        }
-    }
-
-    function getRevertReason(uint256 maxLen) internal pure returns (string memory errorString) {
-        assembly {
-            let len := returndatasize()
-            if gt(len, maxLen) {
-                len := maxLen
-            }
-            let ptr := mload(0x40)
-            mstore(0x40, add(ptr, len))
-            mstore(ptr, len)
-            returndatacopy(ptr, 0, len)
-            errorString := ptr
         }
     }
 

--- a/4337/contracts/test/TestEntryPoint.sol
+++ b/4337/contracts/test/TestEntryPoint.sol
@@ -39,6 +39,7 @@ contract SenderCreator {
 contract TestEntryPoint is INonceManager {
     error NotEnoughFunds(uint256 expected, uint256 available);
     error InvalidNonce(uint256 userNonce);
+    event UserOpReverted();
     SenderCreator public immutable senderCreator;
     mapping(address => uint256) balances;
     mapping(address => mapping(uint192 => uint256)) public nonceSequenceNumber;
@@ -76,7 +77,10 @@ contract TestEntryPoint is INonceManager {
         }
 
         require(gasleft() > userOp.callGasLimit, "Not enough gas for execution");
-        userOp.sender.call{gas: userOp.callGasLimit}(userOp.callData);
+        (bool success, ) = userOp.sender.call{gas: userOp.callGasLimit}(userOp.callData);
+        if (!success) {
+            emit UserOpReverted();
+        }
     }
 
     function getNonce(address sender, uint192 key) external view override returns (uint256 nonce) {

--- a/4337/contracts/test/TestReverter.sol
+++ b/4337/contracts/test/TestReverter.sol
@@ -1,0 +1,7 @@
+pragma solidity >=0.8.0;
+
+contract TestReverter {
+    function alwaysReverting() external pure {
+        revert("You called a function that always reverts");
+    }
+}

--- a/4337/src/utils/safe.ts
+++ b/4337/src/utils/safe.ts
@@ -14,6 +14,7 @@ const INTERFACES = new ethers.utils.Interface([
     'function proxyCreationCode() returns (bytes)',
     'function enableModules(address[])',
     'function execTransactionFromModule(address to, uint256 value, bytes calldata data, uint8 operation) external payable returns (bool success)',
+    'function executeUserOp(bytes executionData)',
     'function getNonce(address,uint192) returns (uint256 nonce)',
     'function supportedEntryPoint() returns (address)',
     'function getOwners() returns (address[])',
@@ -70,7 +71,7 @@ const calculateProxyAddress = (globalConfig: GlobalConfig, inititalizer: string,
   };
 
 const buildInitParamsForConfig = (safeConfig: SafeConfig, globalConfig: GlobalConfig): { safeAddress: string, initCode: string } => {
-    const initData = INTERFACES.encodeFunctionData("enableModules", [[globalConfig.erc4337module, globalConfig.entryPoint]])
+    const initData = INTERFACES.encodeFunctionData("enableModules", [[globalConfig.erc4337module]])
     const setupData = INTERFACES.encodeFunctionData("setup", [
         safeConfig.signers, safeConfig.threshold, globalConfig.addModulesLib, initData, globalConfig.erc4337module, constants.AddressZero, 0, constants.AddressZero
     ])
@@ -95,9 +96,14 @@ const callInterface = async(provider: providers.Provider, contract: string, meth
 }
 
 const actionCalldata = (action: MetaTransaction): string => {
-    return INTERFACES.encodeFunctionData(
+    const execTransactionFromModuleCallData = INTERFACES.encodeFunctionData(
         'execTransactionFromModule',
         [action.to, action.value, action.data, action.operation]
+    )
+
+    return INTERFACES.encodeFunctionData(
+        'executeUserOp',
+        [execTransactionFromModuleCallData]
     )
 }
 

--- a/4337/src/utils/safe.ts
+++ b/4337/src/utils/safe.ts
@@ -14,7 +14,7 @@ const INTERFACES = new ethers.utils.Interface([
     'function proxyCreationCode() returns (bytes)',
     'function enableModules(address[])',
     'function execTransactionFromModule(address to, uint256 value, bytes calldata data, uint8 operation) external payable returns (bool success)',
-    'function executeUserOp(bytes executionData)',
+    'function executeUserOp(address to, uint256 value, bytes calldata data, uint8 operation)',
     'function getNonce(address,uint192) returns (uint256 nonce)',
     'function supportedEntryPoint() returns (address)',
     'function getOwners() returns (address[])',
@@ -96,14 +96,9 @@ const callInterface = async(provider: providers.Provider, contract: string, meth
 }
 
 const actionCalldata = (action: MetaTransaction): string => {
-    const execTransactionFromModuleCallData = INTERFACES.encodeFunctionData(
-        'execTransactionFromModule',
-        [action.to, action.value, action.data, action.operation]
-    )
-
     return INTERFACES.encodeFunctionData(
         'executeUserOp',
-        [execTransactionFromModuleCallData]
+        [action.to, action.value, action.data, action.operation]
     )
 }
 

--- a/4337/src/utils/userOp.ts
+++ b/4337/src/utils/userOp.ts
@@ -87,12 +87,15 @@ export const buildSafeUserOpTransaction = (
   nonce: string,
   entryPoint: string,
   delegateCall?: boolean,
+  bubbleUpRevertReason?: boolean,
   overrides?: Partial<SafeUserOperation>,
 ): SafeUserOperation => {
   const abi = [
     'function executeUserOp(address to, uint256 value, bytes calldata data, uint8 operation) external',
+    'function executeUserOpWithErrorString(address to, uint256 value, bytes calldata data, uint8 operation) external',
   ]
-  const callData = new ethersUtils.Interface(abi).encodeFunctionData('executeUserOp', [to, value, data, delegateCall ? 1 : 0])
+  const method = bubbleUpRevertReason ? 'executeUserOpWithErrorString' : 'executeUserOp'
+  const callData = new ethersUtils.Interface(abi).encodeFunctionData(method, [to, value, data, delegateCall ? 1 : 0])
 
   return buildSafeUserOp(
     Object.assign(
@@ -116,11 +119,12 @@ export const buildSafeUserOpContractCall = (
   operationValue: string,
   entryPoint: string,
   delegateCall?: boolean,
+  bubbleUpRevertReason?: boolean,
   overrides?: Partial<SafeUserOperation>,
 ): SafeUserOperation => {
   const data = contract.interface.encodeFunctionData(method, params)
 
-  return buildSafeUserOpTransaction(safeAddress, contract.address, operationValue, data, nonce, entryPoint, delegateCall, overrides)
+  return buildSafeUserOpTransaction(safeAddress, contract.address, operationValue, data, nonce, entryPoint, delegateCall, bubbleUpRevertReason, overrides)
 }
 
 export const buildUserOperationFromSafeUserOperation = ({

--- a/4337/src/utils/userOp.ts
+++ b/4337/src/utils/userOp.ts
@@ -90,11 +90,9 @@ export const buildSafeUserOpTransaction = (
   overrides?: Partial<SafeUserOperation>,
 ): SafeUserOperation => {
   const abi = [
-    'function execTransactionFromModule(address to, uint256 value, bytes calldata data, uint8 operation) external payable returns (bool success)',
-    'function executeUserOp(bytes calldata executionData) external',
+    'function executeUserOp(address to, uint256 value, bytes calldata data, uint8 operation) external',
   ]
-  const execTransactionFromModuleCallData = new ethersUtils.Interface(abi).encodeFunctionData('execTransactionFromModule', [to, value, data, delegateCall ? 1 : 0])
-  const callData = new ethersUtils.Interface(abi).encodeFunctionData('executeUserOp', [execTransactionFromModuleCallData])
+  const callData = new ethersUtils.Interface(abi).encodeFunctionData('executeUserOp', [to, value, data, delegateCall ? 1 : 0])
 
   return buildSafeUserOp(
     Object.assign(

--- a/4337/src/utils/userOp.ts
+++ b/4337/src/utils/userOp.ts
@@ -50,16 +50,16 @@ export const calculateSafeOperationHash = (eip4337ModuleAddress: string, safeOp:
   return ethersUtils._TypedDataEncoder.hash({ chainId, verifyingContract: eip4337ModuleAddress }, EIP712_SAFE_OPERATION_TYPE, safeOp)
 }
 
-export const signSafeOp = async(
+export const signSafeOp = async (
   signer: Signer & TypedDataSigner,
   moduleAddress: string,
   safeOp: SafeUserOperation,
   chainId: BigNumberish
-  ): Promise<SafeSignature> => {
-    return {
-      signer: await signer.getAddress(),
-      data: await signer._signTypedData({ chainId, verifyingContract: moduleAddress }, EIP712_SAFE_OPERATION_TYPE, safeOp),
-    }
+): Promise<SafeSignature> => {
+  return {
+    signer: await signer.getAddress(),
+    data: await signer._signTypedData({ chainId, verifyingContract: moduleAddress }, EIP712_SAFE_OPERATION_TYPE, safeOp),
+  }
 }
 
 export const buildSafeUserOp = (template: OptionalExceptFor<SafeUserOperation, 'safe' | 'nonce' | 'entryPoint'>): SafeUserOperation => {
@@ -91,8 +91,10 @@ export const buildSafeUserOpTransaction = (
 ): SafeUserOperation => {
   const abi = [
     'function execTransactionFromModule(address to, uint256 value, bytes calldata data, uint8 operation) external payable returns (bool success)',
+    'function executeUserOp(bytes calldata executionData) external',
   ]
-  const callData = new ethersUtils.Interface(abi).encodeFunctionData('execTransactionFromModule', [to, value, data, delegateCall ? 1 : 0])
+  const execTransactionFromModuleCallData = new ethersUtils.Interface(abi).encodeFunctionData('execTransactionFromModule', [to, value, data, delegateCall ? 1 : 0])
+  const callData = new ethersUtils.Interface(abi).encodeFunctionData('executeUserOp', [execTransactionFromModuleCallData])
 
   return buildSafeUserOp(
     Object.assign(
@@ -178,6 +180,6 @@ export const calculateIntermediateTxHash = (callData: string, nonce: BigNumberis
 
 export const getSupportedEntryPoints = async (provider: ethers.providers.JsonRpcProvider): Promise<string[]> => {
   const supportedEntryPoints = await provider.send('eth_supportedEntryPoints', [])
-  console.log({supportedEntryPoints})
+  console.log({ supportedEntryPoints })
   return supportedEntryPoints.map(ethers.utils.getAddress)
 }

--- a/4337/test/eip4337/EIP4337ModuleExisting.spec.ts
+++ b/4337/test/eip4337/EIP4337ModuleExisting.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
 
-describe('EIP4337Module', async () => {
+describe('EIP4337Module - Existing Safe', async () => {
   const [user1] = waffle.provider.getWallets()
 
   const setupTests = deployments.createFixture(async ({ deployments }) => {
@@ -110,6 +110,23 @@ describe('EIP4337Module', async () => {
         entryPoint.executeUserOp(userOp, ethers.utils.parseEther("0.000001"))
       )
       expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther("0.499999"))
+    })
+
+    it('reverts on failure', async () => {
+      const { safe, validator, entryPoint } = await setupTests()
+
+      await user1.sendTransaction({to: safe.address, value: ethers.utils.parseEther("0.000001")})
+      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther("0.000001"))
+      const safeOp = buildSafeUserOpTransaction(safe.address, user1.address, ethers.utils.parseEther("0.5"), "0x", '0', entryPoint.address)
+      const safeOpHash = calculateSafeOperationHash(validator.address, safeOp, await chainId())
+      const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
+      const userOp = buildUserOperationFromSafeUserOperation({safeAddress: safe.address, safeOp, signature})
+
+      const transaction = await entryPoint.executeUserOp(userOp, ethers.utils.parseEther("0.000001")).then((tx: any) => tx.wait())
+      const logs = transaction.logs.map((log: any) => entryPoint.interface.parseLog(log))
+      const emittedRevert = logs.some((l: any) => l.name === "UserOpReverted")
+
+      expect(emittedRevert).to.be.true
     })
   })
 })

--- a/4337/test/eip4337/EIP4337ModuleExisting.spec.ts
+++ b/4337/test/eip4337/EIP4337ModuleExisting.spec.ts
@@ -128,5 +128,25 @@ describe('EIP4337Module - Existing Safe', async () => {
 
       expect(emittedRevert).to.be.true
     })
+
+    it('executeUserOpWithErrorString reverts on failure and bubbles up the revert reason', async () => {
+      const { safe, validator, entryPoint } = await setupTests()
+      const reverterContract = await ethers.getContractFactory("TestReverter").then(factory => factory.deploy())
+      const callData = reverterContract.interface.encodeFunctionData("alwaysReverting", [])
+
+      await user1.sendTransaction({to: safe.address, value: ethers.utils.parseEther("0.000001")})
+      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther("0.000001"))
+      const safeOp = buildSafeUserOpTransaction(safe.address, reverterContract.address, 0, callData, '0', entryPoint.address, false, true)
+      const safeOpHash = calculateSafeOperationHash(validator.address, safeOp, await chainId())
+      const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
+      const userOp = buildUserOperationFromSafeUserOperation({safeAddress: safe.address, safeOp, signature})
+
+      const transaction = await entryPoint.executeUserOp(userOp, ethers.utils.parseEther("0.000001")).then((tx: any) => tx.wait())
+      const logs = transaction.logs.map((log: any) => entryPoint.interface.parseLog(log))
+      const emittedRevert = logs.find((l: any) => l.name === "UserOpReverted")
+      const decodedError = ethers.utils.defaultAbiCoder.decode(["string"], `0x${emittedRevert.args.reason.slice(10)}`)
+      expect(decodedError[0]).to.equal("You called a function that always reverts")
+
+    })
   })
 })

--- a/4337/test/eip4337/EIP4337ModuleNew.spec.ts
+++ b/4337/test/eip4337/EIP4337ModuleNew.spec.ts
@@ -11,7 +11,7 @@ import {
 import { chainId } from '../utils/encoding'
 import { Safe4337 } from '../../src/utils/safe'
 
-describe('EIP4337Module', async () => {
+describe('EIP4337Module - Newly deployed safe', async () => {
   const [user1] = waffle.provider.getWallets()
 
   const setupTests = deployments.createFixture(async ({ deployments }) => {

--- a/4337/test/eip4337/EIP4337Safe.spec.ts
+++ b/4337/test/eip4337/EIP4337Safe.spec.ts
@@ -16,7 +16,7 @@ describe('EIP4337Safe', async () => {
 
   const setupTests = deployments.createFixture(async ({ deployments }) => {
     await deployments.fixture()
-    
+
     const entryPoint = await getEntryPoint()
     const module = await getSimple4337Module()
     const safe = await get4337TestSafe(user1, ethers.constants.AddressZero, ethers.constants.AddressZero)
@@ -25,7 +25,7 @@ describe('EIP4337Safe', async () => {
     return {
       safe,
       validator: safe4337,
-      entryPoint
+      entryPoint,
     }
   })
 
@@ -54,33 +54,27 @@ describe('EIP4337Safe', async () => {
     it('should execute contract calls without fee', async () => {
       const { safe, validator, entryPoint } = await setupTests()
 
-      await user1.sendTransaction({to: safe.address, value: ethers.utils.parseEther("1.0")})
-      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther("1.0"))
-      const safeOp = buildSafeUserOpTransaction(safe.address, user1.address, ethers.utils.parseEther("0.5"), "0x", '0', entryPoint.address)
+      await user1.sendTransaction({ to: safe.address, value: ethers.utils.parseEther('1.0') })
+      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther('1.0'))
+      const safeOp = buildSafeUserOpTransaction(safe.address, user1.address, ethers.utils.parseEther('0.5'), '0x', '0', entryPoint.address)
       const safeOpHash = calculateSafeOperationHash(validator.address, safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({safeAddress: safe.address, safeOp, signature})
-      await logGas(
-        "Execute UserOp without fee payment",
-        entryPoint.executeUserOp(userOp, 0)
-      )
-      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther("0.5"))
+      const userOp = buildUserOperationFromSafeUserOperation({ safeAddress: safe.address, safeOp, signature })
+      await logGas('Execute UserOp without fee payment', entryPoint.executeUserOp(userOp, 0))
+      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther('0.5'))
     })
 
     it('should execute contract calls with fee', async () => {
       const { safe, validator, entryPoint } = await setupTests()
 
-      await user1.sendTransaction({to: safe.address, value: ethers.utils.parseEther("1.0")})
-      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther("1.0"))
-      const safeOp = buildSafeUserOpTransaction(safe.address, user1.address, ethers.utils.parseEther("0.5"), "0x", '0', entryPoint.address)
+      await user1.sendTransaction({ to: safe.address, value: ethers.utils.parseEther('1.0') })
+      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther('1.0'))
+      const safeOp = buildSafeUserOpTransaction(safe.address, user1.address, ethers.utils.parseEther('0.5'), '0x', '0', entryPoint.address)
       const safeOpHash = calculateSafeOperationHash(validator.address, safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({safeAddress: safe.address, safeOp, signature})
-      await logGas(
-        "Execute UserOp with fee payment",
-        entryPoint.executeUserOp(userOp, ethers.utils.parseEther("0.000001"))
-      )
-      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther("0.499999"))
+      const userOp = buildUserOperationFromSafeUserOperation({ safeAddress: safe.address, safeOp, signature })
+      await logGas('Execute UserOp with fee payment', entryPoint.executeUserOp(userOp, ethers.utils.parseEther('0.000001')))
+      expect(await ethers.provider.getBalance(safe.address)).to.be.eq(ethers.utils.parseEther('0.499999'))
     })
   })
 })


### PR DESCRIPTION
This PR:
- Extracts the execution function of a user operation into a separate function on the module (previously, the entrypoint would directly call `execTransactionFromModule` and had to be enabled as a module as well
- This was done to require `success` and revert on failing transactions to enable a proper gas estimation

This PR is a prototype only at the moment, and the goal is to seek the team's feedback on the approach.