### PR TITLE
Feature: Add an optional ERC20 transfer in the `runOp.ts` script to test contract calls

### DIFF
--- a/4337/.env.sample
+++ b/4337/.env.sample
@@ -19,6 +19,8 @@ SCRIPT_ADD_MODULES_LIB_ADDRESS=""
 SCRIPT_PROXY_FACTORY_ADDRESS=
 # Singleton address to use in the user op test script
 SCRIPT_SAFE_SINGLETON_ADDRESS=
+# ERC20 Token to use in the user op test script for testing contract calls
+SCRIPT_ERC20_TOKEN_ADDRESS=
 
 # Entrypoint address to use for the module deployment
 DEPLOY_ENTRY_POINT=""

--- a/4337/.env.sample
+++ b/4337/.env.sample
@@ -12,16 +12,16 @@ SCRIPT_DEBUG=true
 # Bundler to use in the user op test script
 SCRIPT_BUNDLER_URL=""
 # Module to use in the user op test script
-SCRIPT_MODULE_ADDRESS=
+SCRIPT_MODULE_ADDRESS=""
 # Library to add modules in the user op test script
 SCRIPT_ADD_MODULES_LIB_ADDRESS=""
 # Proxy factory to use in the user op test script
-SCRIPT_PROXY_FACTORY_ADDRESS=
+SCRIPT_PROXY_FACTORY_ADDRESS=""
 # Singleton address to use in the user op test script
-SCRIPT_SAFE_SINGLETON_ADDRESS=
+SCRIPT_SAFE_SINGLETON_ADDRESS=""
 # ERC20 Token to use in the user op test script for testing contract calls. Token should have 18 decimals. Safe should have 1 token.
 # Optional. If set, the runOp script will execute a token transfer out of the Safe
-SCRIPT_ERC20_TOKEN_ADDRESS=
+SCRIPT_ERC20_TOKEN_ADDRESS=""
 
 # Entrypoint address to use for the module deployment
 DEPLOY_ENTRY_POINT=""

--- a/4337/.env.sample
+++ b/4337/.env.sample
@@ -19,7 +19,8 @@ SCRIPT_ADD_MODULES_LIB_ADDRESS=""
 SCRIPT_PROXY_FACTORY_ADDRESS=
 # Singleton address to use in the user op test script
 SCRIPT_SAFE_SINGLETON_ADDRESS=
-# ERC20 Token to use in the user op test script for testing contract calls
+# ERC20 Token to use in the user op test script for testing contract calls. Token should have 18 decimals. Safe should have 1 token.
+# Optional. If set, the runOp script will execute a token transfer out of the Safe
 SCRIPT_ERC20_TOKEN_ADDRESS=
 
 # Entrypoint address to use for the module deployment

--- a/4337/contracts/test/TestToken.sol
+++ b/4337/contracts/test/TestToken.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+
+contract HariWillibaldToken is ERC20, ERC20Permit {
+    constructor(address initialMintDest) ERC20("Hari Willibald Token", "HWT") ERC20Permit("Hari Willibald Token") {
+        _mint(initialMintDest, 1000000 * 10**decimals());
+    }
+}

--- a/4337/hardhat.config.ts
+++ b/4337/hardhat.config.ts
@@ -36,7 +36,7 @@ import './src/tasks/local_verify'
 import './src/tasks/deploy_contracts'
 import './src/tasks/show_codesize'
 
-const primarySolidityVersion = SOLIDITY_VERSION || '0.8.14'
+const primarySolidityVersion = SOLIDITY_VERSION || '0.8.20'
 const soliditySettings = !!SOLIDITY_SETTINGS ? JSON.parse(SOLIDITY_SETTINGS) : { optimizer: { enabled: true, runs: 200 } }
 
 const userConfig: HardhatUserConfig = {
@@ -47,7 +47,7 @@ const userConfig: HardhatUserConfig = {
     sources: 'contracts',
   },
   solidity: {
-    compilers: [{ version: primarySolidityVersion, settings: soliditySettings }, { version: '0.6.12' }, { version: '0.5.17' }],
+    compilers: [{ version: primarySolidityVersion, settings: { evmVersion: 'london', ...soliditySettings }}, { version: '0.6.12' }, { version: '0.5.17' }],
   },
   networks: {
     hardhat: {

--- a/4337/package-lock.json
+++ b/4337/package-lock.json
@@ -15,6 +15,7 @@
         "@nomiclabs/hardhat-ethers": "^2.0.6",
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
         "@nomiclabs/hardhat-waffle": "^2.0.3",
+        "@openzeppelin/contracts": "^5.0.0",
         "@types/chai": "^4.3.1",
         "@types/mocha": "^9.1.1",
         "@types/node": "^17.0.42",
@@ -1423,6 +1424,12 @@
         "ethers": "^5.0.0",
         "hardhat": "^2.0.0"
       }
+    },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.0.tgz",
+      "integrity": "sha512-bv2sdS6LKqVVMLI5+zqnNrNU/CA+6z6CmwFXm/MzmOPBRSO5reEJN7z0Gbzvs0/bv/MZZXNklubpwy3v2+azsw==",
+      "dev": true
     },
     "node_modules/@resolver-engine/core": {
       "version": "0.3.3",
@@ -18398,6 +18405,12 @@
         "@types/sinon-chai": "^3.2.3",
         "@types/web3": "1.0.19"
       }
+    },
+    "@openzeppelin/contracts": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.0.tgz",
+      "integrity": "sha512-bv2sdS6LKqVVMLI5+zqnNrNU/CA+6z6CmwFXm/MzmOPBRSO5reEJN7z0Gbzvs0/bv/MZZXNklubpwy3v2+azsw==",
+      "dev": true
     },
     "@resolver-engine/core": {
       "version": "0.3.3",

--- a/4337/package.json
+++ b/4337/package.json
@@ -46,6 +46,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
+    "@openzeppelin/contracts": "^5.0.0",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.42",

--- a/4337/scripts/runOp.ts
+++ b/4337/scripts/runOp.ts
@@ -17,6 +17,7 @@ const SAFE_SINGLETON_ADDRESS = process.env.SCRIPT_SAFE_SINGLETON_ADDRESS!!
 const PROXY_FACTORY_ADDRESS = process.env.SCRIPT_PROXY_FACTORY_ADDRESS!!
 const ADD_MODULES_LIB_ADDRESS = process.env.SCRIPT_ADD_MODULES_LIB_ADDRESS!!
 const MODULE_ADDRESS = process.env.SCRIPT_MODULE_ADDRESS!!
+const ERC20_TOKEN_ADDRESS = process.env.SCRIPT_ERC20_TOKEN_ADDRESS!!
 
 const INTERFACES = new ethers.utils.Interface([
   'function enableModule(address)',
@@ -79,10 +80,16 @@ const runOp = async () => {
     await(await user1.sendTransaction({to: safe.address, value: ethers.utils.parseEther("0.01")})).wait()
   }
 
+  let toAddress = '0x02270bd144e70cE6963bA02F575776A16184E1E6'
+  let callData = "0x"
+  if (ERC20_TOKEN_ADDRESS) {
+    toAddress = ERC20_TOKEN_ADDRESS
+    callData = buildData("transfer(address,uint256)", [user1.address, parseEther('1')])
+  }
   const operation = await safe.operate({
-    to: '0x02270bd144e70cE6963bA02F575776A16184E1E6',
+    to: toAddress,
     value: parseEther('0.0001'),
-    data: '0x',
+    data: callData,
     operation: 0
   })
   

--- a/4337/scripts/runOp.ts
+++ b/4337/scripts/runOp.ts
@@ -9,6 +9,7 @@ import { chainId } from '../test/utils/encoding'
 import { getSimple4337Module } from '../test/utils/setup'
 import { Result } from 'ethers/lib/utils'
 import { GlobalConfig, MultiProvider4337, Safe4337 } from '../src/utils/safe'
+import { BigNumberish } from 'ethers'
 
 const DEBUG = process.env.SCRIPT_DEBUG || false
 const MNEMONIC = process.env.SCRIPT_MNEMONIC
@@ -82,13 +83,15 @@ const runOp = async () => {
 
   let toAddress = '0x02270bd144e70cE6963bA02F575776A16184E1E6'
   let callData = "0x"
+  let value: BigNumberish = parseEther('0.0001')
   if (ERC20_TOKEN_ADDRESS) {
     toAddress = ERC20_TOKEN_ADDRESS
     callData = buildData("transfer(address,uint256)", [user1.address, parseEther('1')])
+    value = 0n
   }
   const operation = await safe.operate({
     to: toAddress,
-    value: parseEther('0.0001'),
+    value,
     data: callData,
     operation: 0
   })

--- a/4337/src/deploy/deploy_eip4337.ts
+++ b/4337/src/deploy/deploy_eip4337.ts
@@ -8,7 +8,7 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await getNamedAccounts()
   const { deploy } = deployments
 
-  let entryPointAddress;
+  let entryPointAddress
   if (hre.network.name === 'hardhat' || !ENTRY_POINT) {
     const entryPoint = await deploy('TestEntryPoint', {
       from: deployer,
@@ -35,6 +35,13 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   } else {
     entryPointAddress = ENTRY_POINT
   }
+
+  await deploy('HariWillibaldToken', {
+    from: deployer,
+    args: [deployer],
+    log: true,
+    deterministicDeployment: true,
+  })
 
   await deploy('Simple4337Module', {
     from: deployer,

--- a/4337/src/deploy/deploy_eip4337.ts
+++ b/4337/src/deploy/deploy_eip4337.ts
@@ -36,13 +36,6 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     entryPointAddress = ENTRY_POINT
   }
 
-  await deploy('HariWillibaldToken', {
-    from: deployer,
-    args: [deployer],
-    log: true,
-    deterministicDeployment: true,
-  })
-
   await deploy('Simple4337Module', {
     from: deployer,
     args: [entryPointAddress],

--- a/4337/src/deploy/deploy_test.ts
+++ b/4337/src/deploy/deploy_test.ts
@@ -6,21 +6,28 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const { deployer } = await getNamedAccounts();
     const { deploy } = deployments;
 
-    if (hre.network.name !== 'hardhat') return
+    if (hre.network.name == 'hardhat') {
+        await deploy("SafeProxyFactory", {
+            from: deployer,
+            args: [],
+            log: true,
+            deterministicDeployment: true,
+        });
 
-    await deploy("SafeProxyFactory", {
+        await deploy("SafeL2", {
+            from: deployer,
+            args: [],
+            log: true,
+            deterministicDeployment: true, 
+        });
+    }
+
+    await deploy('HariWillibaldToken', {
         from: deployer,
-        args: [],
+        args: [deployer],
         log: true,
         deterministicDeployment: true,
-    });
-
-    await deploy("SafeL2", {
-        from: deployer,
-        args: [],
-        log: true,
-        deterministicDeployment: true,
-    });
+    })
 };
 
 deploy.tags = ["factory", "l2-suite", "main-suite"];

--- a/4337/src/utils/execution.ts
+++ b/4337/src/utils/execution.ts
@@ -35,7 +35,7 @@ export const EIP712_SAFE_MESSAGE_TYPE = {
 
 export interface MetaTransaction {
   to: string
-  value: string | number | BigNumber
+  value: BigNumberish
   data: string
   operation: number
 }
@@ -222,7 +222,7 @@ export const executeContractCallWithSigners = async (
 
 export const buildSafeTransaction = (template: {
   to: string
-  value?: BigNumber | number | string
+  value?: BigNumberish
   data?: string
   operation?: number
   safeTxGas?: number | string

--- a/4337/tsconfig.json
+++ b/4337/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "es2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": ["ES2015"],
     "allowJs": false /* Allow javascript files to be compiled. */,


### PR DESCRIPTION
This PR:
- Adds an optional ERC20 transfer execution in the `runOp` script to test contract calls
- Executes if the environment variable for the token address is set. The pre-requisite is Safe should own at least one token. It will transfer precisely 1.
- The token name is coming from https://www.behindthename.com/random/random.php?gender=both&number=2&sets=1&surname=&all=yes

Notes:
- I had to bump the compiler version to `0.8.20` because of openzeppelin's token requirements and change the default EVM target from `Shanghai` to `London`, because Mumbai didn't support the `PUSH0` opcode added in `Shanghai`
- I also had to bump the target ES spec to `es2020` to use BigInts

