### PR TITLE
Define CODEOWNERS Files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @safe-global/safe-protocol


### PR DESCRIPTION
This PR adds a `CODEOWNERS` file. The motivation for adding this [is](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners):

> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

Here, we setup the `safe-protocol` team to be the code owner for all files in this repository, so PRs that are created to this repo will automatically request a review from that team.