### PR TITLE
Skip Coverage for Test Contracts

### DIFF
--- a/4337/.solcover.js
+++ b/4337/.solcover.js
@@ -1,5 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+const testDir = path.join(__dirname, 'contracts', 'test');
+const testContracts = fs.readdirSync(testDir)
+    .filter((file) => file.endsWith('.sol'))
+    .map((file) => path.join('test', file));
+
 module.exports = {
-    skipFiles: [],
+    skipFiles: testContracts,
     mocha: {
         grep: '@skip-on-coverage', // Find everything with this tag
         invert: true, // Run the grep's inverse set.


### PR DESCRIPTION
As test coverage for test contracts is not really important, we should skip it in the coverage report (so that it only reflects test coverage for the core contracts of the repo).