### PR TITLE
Include 4337 Module Link in Project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a collection of modules that can be used with the [Safe
 Modules
 -------
 
+- [4337 Module](./4337)
 - [Allowance Module](./allowances)
 - [DutchX Seller Module](./dutchx_seller)
 - [Recurring Transfers Module](./recurring_transfers)


### PR DESCRIPTION
Just a small README fix.