### PR TITLE
Rename `requiredPrefund` to `missingAccountFunds`

### DIFF
--- a/4337/.prettierrc
+++ b/4337/.prettierrc
@@ -8,8 +8,7 @@
         "tabWidth": 4,
         "useTabs": false,
         "singleQuote": false,
-        "bracketSpacing": false,
-        "explicitTypes": "always"
+        "bracketSpacing": false
       }
     }
   ],

--- a/4337/contracts/EIP4337Module.sol
+++ b/4337/contracts/EIP4337Module.sol
@@ -38,11 +38,13 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
 
     /**
      * @notice Validates a user operation provided by the entry point.
-     * @param userOp User operation struct.
-     * @param requiredPrefund Required prefund to execute the operation.
-     * @return validationResult An integer indicating the result of the validation.
+     * @inheritdoc IAccount
      */
-    function validateUserOp(UserOperation calldata userOp, bytes32, uint256 requiredPrefund) external returns (uint256 validationResult) {
+    function validateUserOp(
+        UserOperation calldata userOp,
+        bytes32,
+        uint256 missingAccountFunds
+    ) external returns (uint256 validationResult) {
         address payable safeAddress = payable(userOp.sender);
         // The entryPoint address is appended to the calldata in `HandlerContext` contract
         // Because of this, the relayer may manipulate the entryPoint address, therefore we have to verify that
@@ -64,8 +66,8 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
 
         // We trust the entrypoint to set the correct prefund value, based on the operation params
         // We need to perform this even if the signature is not valid, else the simulation function of the Entrypoint will not work
-        if (requiredPrefund != 0) {
-            ISafe(safeAddress).execTransactionFromModule(entryPoint, requiredPrefund, "", 0);
+        if (missingAccountFunds != 0) {
+            ISafe(safeAddress).execTransactionFromModule(entryPoint, missingAccountFunds, "", 0);
         }
     }
 

--- a/4337/contracts/interfaces/Safe.sol
+++ b/4337/contracts/interfaces/Safe.sol
@@ -9,12 +9,7 @@ interface ISafe {
      * @param data Data payload of module transaction.
      * @param operation Operation type of module transaction.
      */
-    function execTransactionFromModule(
-        address to,
-        uint256 value,
-        bytes memory data,
-        uint8 operation
-    ) external returns (bool success);
+    function execTransactionFromModule(address to, uint256 value, bytes memory data, uint8 operation) external returns (bool success);
 
     /**
      * @notice Execute `operation` (0: Call, 1: DelegateCall) to `to` with `value` (Native Token) and return data
@@ -38,11 +33,7 @@ interface ISafe {
      * @param data That should be signed (this is passed to an external validator contract)
      * @param signatures Signature data that should be verified. Can be ECDSA signature, contract signature (EIP-1271) or approved hash.
      */
-    function checkSignatures(
-        bytes32 dataHash,
-        bytes memory data,
-        bytes memory signatures
-    ) external view;
+    function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures) external view;
 
     function domainSeparator() external view returns (bytes32);
 

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -2,9 +2,7 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity >=0.8.0;
 
-import "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol";
-import "@safe-global/safe-contracts/contracts/SafeL2.sol";
-
+import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";
 import {INonceManager} from "@account-abstraction/contracts/interfaces/INonceManager.sol";
 import {UserOperation, UserOperationLib} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 
@@ -98,7 +96,7 @@ contract SafeMock {
     receive() external payable {}
 }
 
-contract Safe4337Mock is SafeMock {
+contract Safe4337Mock is SafeMock, IAccount {
     using UserOperationLib for UserOperation;
     bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
 
@@ -110,9 +108,8 @@ contract Safe4337Mock is SafeMock {
     constructor(address entryPoint) SafeMock(entryPoint) {}
 
     /// @dev Validates user operation provided by the entry point
-    /// @param userOp User operation struct
-    /// @param requiredPrefund Required prefund to execute the operation
-    function validateUserOp(UserOperation calldata userOp, bytes32, uint256 requiredPrefund) external returns (uint256) {
+    /// @inheritdoc IAccount
+    function validateUserOp(UserOperation calldata userOp, bytes32, uint256 missingAccountFunds) external returns (uint256) {
         address entryPoint = msg.sender;
         require(entryPoint == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
 
@@ -127,8 +124,8 @@ contract Safe4337Mock is SafeMock {
 
         _validateSignatures(entryPoint, userOp);
 
-        if (requiredPrefund != 0) {
-            (bool success, ) = entryPoint.call{value: requiredPrefund}("");
+        if (missingAccountFunds != 0) {
+            (bool success, ) = entryPoint.call{value: missingAccountFunds}("");
             success;
         }
         return 0;

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable no-global-import */
 /* solhint-disable one-contract-per-file */
 pragma solidity >=0.8.0;
+
+import "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol";
+import "@safe-global/safe-contracts/contracts/SafeL2.sol";
 
 import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";
 import {INonceManager} from "@account-abstraction/contracts/interfaces/INonceManager.sol";

--- a/4337/contracts/test/TestEntryPoint.sol
+++ b/4337/contracts/test/TestEntryPoint.sol
@@ -54,13 +54,17 @@ contract TestEntryPoint is INonceManager {
 
         require(gasleft() > userOp.verificationGasLimit, "Not enough gas for verification");
 
+        uint256 userBalance = balances[userOp.sender];
+        uint256 missingAccountFunds = requiredPrefund > userBalance ? requiredPrefund - userBalance : 0;
+
         uint256 validationResult = IAccount(userOp.sender).validateUserOp{gas: userOp.verificationGasLimit}(
             userOp,
             bytes32(0),
-            requiredPrefund
+            missingAccountFunds
         );
         require(validationResult == 0, "Signature validation failed");
-        uint256 userBalance = balances[userOp.sender];
+
+        userBalance = balances[userOp.sender];
         if (userBalance < requiredPrefund) {
             revert NotEnoughFunds(requiredPrefund, userBalance);
         }

--- a/4337/package.json
+++ b/4337/package.json
@@ -25,7 +25,7 @@
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "lint:ts": "eslint ./src && eslint ./test",
     "fmt": "prettier --ignore-path .gitignore --write . && prettier --write 'contracts/**/*.sol'",
-    "fmt:check": "prettier --ignore-path .gitignore --check .",
+    "fmt:check": "prettier --ignore-path .gitignore --check . && prettier --check 'contracts/**/*.sol'",
     "prepack": "yarn build",
     "prepare": "cd .. && husky install 4337/.husky",
     "prepublish": "yarn rimraf build && yarn build && yarn build:ts"

--- a/4337/package.json
+++ b/4337/package.json
@@ -24,7 +24,7 @@
     "lint": "yarn lint:sol && yarn lint:ts",
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "lint:ts": "eslint ./src && eslint ./test",
-    "fmt": "prettier --ignore-path .gitignore --write .",
+    "fmt": "prettier --ignore-path .gitignore --write . && prettier --write 'contracts/**/*.sol'",
     "fmt:check": "prettier --ignore-path .gitignore --check .",
     "prepack": "yarn build",
     "prepare": "cd .. && husky install 4337/.husky",


### PR DESCRIPTION
This PR applies a minor suggestion resulting from the audit where the `validateUserOp` parameter names (specifically for the required account fund transfer to the entrypoint) did not exactly match the name from the ERC.

Note that the test entrypoint was slightly adjusted to more closely model the behaviour of the [reference entrypoint](https://github.com/eth-infinitism/account-abstraction/blob/94cf025ef1c07b4b404ecd1c732266b378caaa92/contracts/core/EntryPoint.sol#L421-L427), where left-over user balances are considered when computing the  `missingAccountFunds` to pass into the `validateUserOp` call:

```solidity
            uint256 missingAccountFunds = 0;
            if (paymaster == address(0)) {
                uint256 bal = balanceOf(sender);
                missingAccountFunds = bal > requiredPrefund
                    ? 0
                    : requiredPrefund - bal;
            }
```

I noticed this while looking for instances of `requiredPrefund` in the codebase. All tests continue to pass 🎉.

Another minor change, I noticed that `prettier .` was not picking up `.sol` files anymore, so I adjusted the NPM scripts to explicitly format and check them.