### PR TITLE
Bump CLA action version, Explicitly Request Required PR Permission for CLA Bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,12 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
@@ -13,7 +19,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@v2.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret


### PR DESCRIPTION
Change the CLA bot to explicitly request the required permissions. This is done in accordance to the CLA bot [documentation](https://github.com/contributor-assistant/github-action#1-add-the-following-workflow-file-to-your-repository-in-this-pathgithubworkflowsclayml):

> ```
> # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
> permissions:
>   actions: write
>   contents: write
>   pull-requests: write
>   statuses: write
> ```