### PR TITLE
Check EntryPoint in Constructor

### DIFF
--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -264,7 +264,7 @@ contract Safe4337Mock is SafeMock, IAccount {
     }
 
     function _validateReplayProtection(UserOperation calldata userOp) internal view {
-        // The entrypoints handles the increase of the nonce
+        // The entry point handles the increase of the nonce
         // Right shifting fills up with 0s from the left
         uint192 key = uint192(userOp.nonce >> 64);
         uint256 safeNonce = INonceManager(SUPPORTED_ENTRYPOINT).getNonce(userOp.sender, key);

--- a/4337/contracts/test/TestEntryPoint.sol
+++ b/4337/contracts/test/TestEntryPoint.sol
@@ -7,7 +7,7 @@ import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOpera
 
 /**
  * helper contract for EntryPoint, to call userOp.initCode from a "neutral" address,
- * which is explicitly not the entryPoint itself.
+ * which is explicitly not the entry point itself.
  */
 contract SenderCreator {
     /**

--- a/4337/test/eip4337/EIP4337Module.spec.ts
+++ b/4337/test/eip4337/EIP4337Module.spec.ts
@@ -34,6 +34,13 @@ describe('Safe4337Module', () => {
     }
   })
 
+  describe('constructor', () => {
+    it('should revert when entry point is not specified', async () => {
+      const factory = await ethers.getContractFactory('Safe4337Module')
+      await expect(factory.deploy(ethers.ZeroAddress)).to.be.revertedWith('Invalid entry point')
+    })
+  })
+
   describe('validateUserOp', () => {
     it('should revert when validating user ops for a different Safe', async () => {
       const { user, entryPoint, validator, safeModule, makeSafeModule } = await setupTests()
@@ -52,7 +59,7 @@ describe('Safe4337Module', () => {
       expect(await safeFromEntryPoint.validateUserOp.staticCall(userOp, ethers.ZeroHash, 0)).to.eq(0)
 
       const otherSafe = (await makeSafeModule(user)).connect(entryPointImpersonator)
-      await expect(otherSafe.validateUserOp.staticCall(userOp, ethers.ZeroHash, 0)).to.be.revertedWith('Invalid Caller')
+      await expect(otherSafe.validateUserOp.staticCall(userOp, ethers.ZeroHash, 0)).to.be.revertedWith('Invalid caller')
     })
 
     it('should revert when calling an unsupported Safe method', async () => {


### PR DESCRIPTION
Addresses another comment resulting from the module audit and verifies the constructor argument is not the `0` address to avoid accidental mistakes that may lead to invalid deployed contracts.

I noticed when deciding the exact revert message to use that there were many ways to spell "entry point" and slightly inconsistent capitalisation in existing messages, so I corrected those as well.