### PR TITLE
Follow Solidity Internal Function Naming Convention

### DIFF
--- a/4337/contracts/Safe4337Module.sol
+++ b/4337/contracts/Safe4337Module.sol
@@ -24,11 +24,11 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
     //
     // Note that this implies that `validUntil = 0` which is defined to be a marker value indicating an "infinite" timestamp,
     // and `validFrom = 0`, meaning that the signature is always valid.
-    uint256 internal constant SIG_VALIDATION_SUCCESS = 0;
+    uint256 private constant SIG_VALIDATION_SUCCESS = 0;
 
     // A constant representing a signature validation failure, defined in the ERC4337 spec.
     // Equivalent to `_packValidationData(true, 0, 0);`
-    uint256 internal constant SIG_VALIDATION_FAILED = 1;
+    uint256 private constant SIG_VALIDATION_FAILED = 1;
 
     bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
 
@@ -65,7 +65,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         require(entryPoint == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
 
         // The userOp nonce is validated in the Entrypoint (for 0.6.0+), therefore we will not check it again
-        validationData = validateSignatures(entryPoint, userOp);
+        validationData = _validateSignatures(entryPoint, userOp);
 
         // We trust the entrypoint to set the correct prefund value, based on the operation params
         // We need to perform this even if the signature is not valid, else the simulation function of the Entrypoint will not work.
@@ -164,7 +164,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @param userOp User operation struct.
      * @return validationData An integer indicating the result of the validation.
      */
-    function validateSignatures(address entryPoint, UserOperation calldata userOp) internal view returns (uint256 validationData) {
+    function _validateSignatures(address entryPoint, UserOperation calldata userOp) internal view returns (uint256 validationData) {
         bytes32 operationHash = getOperationHash(
             payable(userOp.sender),
             userOp.callData,

--- a/4337/contracts/interfaces/Safe.sol
+++ b/4337/contracts/interfaces/Safe.sol
@@ -35,6 +35,10 @@ interface ISafe {
      */
     function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures) external view;
 
+    /**
+     * @dev Returns the domain separator for this contract, as defined in the EIP-712 standard.
+     * @return bytes32 The domain separator hash.
+     */
     function domainSeparator() external view returns (bytes32);
 
     /**

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -31,7 +31,7 @@ contract SafeMock {
         modules[SUPPORTED_ENTRYPOINT] = true;
     }
 
-    function signatureSplit(bytes memory signature) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
+    function _signatureSplit(bytes memory signature) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             r := mload(add(signature, 0x20))
@@ -44,7 +44,7 @@ contract SafeMock {
         uint8 v;
         bytes32 r;
         bytes32 s;
-        (v, r, s) = signatureSplit(signature);
+        (v, r, s) = _signatureSplit(signature);
         require(
             owner == ecrecover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", dataHash)), v, r, s),
             "Invalid signature"
@@ -117,7 +117,7 @@ contract Safe4337Mock is SafeMock, IAccount {
         address entryPoint = msg.sender;
         require(entryPoint == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
 
-        validateReplayProtection(userOp);
+        _validateReplayProtection(userOp);
 
         // We check the execution function signature to make sure the entryPoint can't call any other function
         // and make sure the execution of the user operation is handled by the module
@@ -263,7 +263,7 @@ contract Safe4337Mock is SafeMock, IAccount {
         checkSignatures(operationHash, operationData, userOp.signature);
     }
 
-    function validateReplayProtection(UserOperation calldata userOp) internal view {
+    function _validateReplayProtection(UserOperation calldata userOp) internal view {
         // The entrypoints handles the increase of the nonce
         // Right shifting fills up with 0s from the left
         uint192 key = uint192(userOp.nonce >> 64);


### PR DESCRIPTION
This PR makes the 4337 Solidity code follow the standard naming convention where internal and private functions should be prefixed with `_`.