### PR TITLE
Fix initCode Computation in README

### DIFF
--- a/4337/README.md
+++ b/4337/README.md
@@ -67,19 +67,34 @@ To deploy a Safe with 4337 directly enabled, we require a setup library that ena
 The `initCode` for the Safe with a 4337 module enabled is composed in the following way:
 
 ```solidity
-/** Enable Modules **/
-bytes memory initExecutor = ADD_MODULES_LIB_ADDRESS;
-bytes memory initData =  abi.encodeWithSignature("enableModules", [4337_MODULE_ADDRESS, ENTRY_POINT_ADDRESS]);
-
 /** Setup Safe **/
-// We do not want to use any payment logic therefore, this is all set to 0
-bytes memory setupData = abi.encodeWithSignature("setup", owners, threshold, initExecutor, initData, 4337_MODULE_ADDRESS, address(0), 0, address(0));
+address[] memory modules = new address[](1);
+{
+    modules[0] = SAFE_4337_MODULE_ADDRESS;
+}
+bytes memory initializer = abi.encodeWithSignature(
+    "setup(address[],uint256,address,bytes,address,address,uint256,address)",
+    owners,
+    threshold,
+    ADD_MODULES_LIB_ADDRESS,
+    abi.encodeWithSignature("enableModules(address[])", modules),
+    SAFE_4337_MODULE_ADDRESS,
+    // We do not want to use any payment logic therefore, this is all set to 0
+    address(0),
+    0,
+    address(0)
+);
 
 /** Deploy Proxy **/
-bytes memory deployData = abi.encodeWithSignature("createProxyWithNonce", SAFE_SINGLETON_ADDRESS, setupData, salt);
+bytes memory initCallData = abi.encodeWithSignature(
+    "createProxyWithNonce(address,bytes,uint256)",
+    SAFE_SINGLETON_ADDRESS,
+    initializer,
+    saltNonce
+);
 
 /** Encode for 4337 **/
-bytes memory initCode = abi.encodePacked(SAFE_PROXY_FACTORY_ADDRESS, deployData);
+bytes memory initCode = abi.encodePacked(SAFE_PROXY_FACTORY_ADDRESS, initCallData);
 ```
 
 The diagram below outlines the flow triggered by the initialization data to deploy a Safe with the 4337 module enabled.

--- a/4337/README.md
+++ b/4337/README.md
@@ -79,7 +79,7 @@ bytes memory initializer = abi.encodeWithSignature(
     ADD_MODULES_LIB_ADDRESS,
     abi.encodeWithSignature("enableModules(address[])", modules),
     SAFE_4337_MODULE_ADDRESS,
-    // We do not want to use any payment logic therefore, this is all set to 0
+    // We do not want to use any refund logic; therefore, this is all set to 0
     address(0),
     0,
     address(0)

--- a/4337/contracts/test/InitCode.sol
+++ b/4337/contracts/test/InitCode.sol
@@ -38,7 +38,7 @@ contract InitCode {
             ADD_MODULES_LIB_ADDRESS,
             abi.encodeWithSignature("enableModules(address[])", modules),
             SAFE_4337_MODULE_ADDRESS,
-            // We do not want to use any payment logic therefore, this is all set to 0
+            // We do not want to use any refund logic; therefore, this is all set to 0
             address(0),
             0,
             address(0)

--- a/4337/contracts/test/InitCode.sol
+++ b/4337/contracts/test/InitCode.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+contract InitCode {
+    struct Config {
+        address addModulesLib;
+        address erc4337module;
+        address safeSingleton;
+        address proxyFactory;
+    }
+
+    address public immutable ADD_MODULES_LIB_ADDRESS;
+    address public immutable SAFE_4337_MODULE_ADDRESS;
+    address public immutable SAFE_SINGLETON_ADDRESS;
+    address public immutable SAFE_PROXY_FACTORY_ADDRESS;
+
+    constructor(Config memory config) {
+        ADD_MODULES_LIB_ADDRESS = config.addModulesLib;
+        SAFE_4337_MODULE_ADDRESS = config.erc4337module;
+        SAFE_SINGLETON_ADDRESS = config.safeSingleton;
+        SAFE_PROXY_FACTORY_ADDRESS = config.proxyFactory;
+    }
+
+    function getInitCode(address[] memory owners, uint256 threshold, uint256 saltNonce) external view returns (bytes memory) {
+        /** Setup Safe **/
+        address[] memory modules = new address[](1);
+        {
+            modules[0] = SAFE_4337_MODULE_ADDRESS;
+        }
+        bytes memory initializer = abi.encodeWithSignature(
+            "setup(address[],uint256,address,bytes,address,address,uint256,address)",
+            owners,
+            threshold,
+            ADD_MODULES_LIB_ADDRESS,
+            abi.encodeWithSignature("enableModules(address[])", modules),
+            SAFE_4337_MODULE_ADDRESS,
+            // We do not want to use any payment logic therefore, this is all set to 0
+            address(0),
+            0,
+            address(0)
+        );
+
+        /** Deploy Proxy **/
+        bytes memory initCallData = abi.encodeWithSignature(
+            "createProxyWithNonce(address,bytes,uint256)",
+            SAFE_SINGLETON_ADDRESS,
+            initializer,
+            saltNonce
+        );
+
+        /** Encode for 4337 **/
+        bytes memory initCode = abi.encodePacked(SAFE_PROXY_FACTORY_ADDRESS, initCallData);
+
+        return initCode;
+    }
+}

--- a/4337/contracts/test/InitCode.sol
+++ b/4337/contracts/test/InitCode.sol
@@ -21,6 +21,10 @@ contract InitCode {
         SAFE_PROXY_FACTORY_ADDRESS = config.proxyFactory;
     }
 
+    /**
+     * @dev Compute ERC-4337 initCode for a new Safe with the Safe4337Module.
+     * @notice CHANGES TO THIS FUNCTION SHOULD BE MIRRORED IN THE README!
+     */
     function getInitCode(address[] memory owners, uint256 threshold, uint256 saltNonce) external view returns (bytes memory) {
         /** Setup Safe **/
         address[] memory modules = new address[](1);

--- a/4337/test/docs/InitCode.spec.ts
+++ b/4337/test/docs/InitCode.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { Safe4337 } from '../../src/utils/safe'
+
+describe('InitCode', () => {
+  const setupTests = async () => {
+    const addr = (byte: number) => `0x${byte.toString(16).padStart(2, '0').repeat(20)}`
+    const config = {
+      safeSingleton: addr(0x01),
+      entryPoint: addr(0x02),
+      erc4337module: addr(0x03),
+      proxyFactory: addr(0x04),
+      addModulesLib: addr(0x05),
+      proxyCreationCode: '0x',
+      chainId: 42,
+    }
+
+    const InitCode = await ethers.getContractFactory('InitCode')
+    const initCode = await InitCode.deploy(config)
+
+    const owner = addr(0xff)
+    const safe = await Safe4337.withSigner(owner, config)
+
+    return {
+      initCode,
+      owner,
+      safe,
+    }
+  }
+
+  it('should compute the valid init code', async () => {
+    const { initCode, owner, safe } = await setupTests()
+
+    expect(await initCode.getInitCode([owner], 1, 0)).to.equal(safe.getInitCode())
+  })
+})


### PR DESCRIPTION
This PR fixes the `initCode` computation code snippet in the README. I also chose to add a small test to verify the code works. Unfortunately, it is manual in that changes to the sample `initCode` computation in Solidity need to be mirrored to the README.