### PR TITLE
Ignore Immutables on Local Verification

### DIFF
--- a/4337/src/tasks/local_verify.ts
+++ b/4337/src/tasks/local_verify.ts
@@ -6,9 +6,7 @@ task('local-verify', 'Verifies that the local deployment files correspond to the
   const deployedContracts = await hre.deployments.all()
   for (const contract of Object.keys(deployedContracts)) {
     const deployment = await hre.deployments.get(contract)
-
     if (!deployment.metadata) throw new Error(`No metadata for ${contract}`)
-
     const meta = JSON.parse(deployment.metadata)
     const solcjs = await loadSolc(meta.compiler.version)
     delete meta.compiler
@@ -21,17 +19,24 @@ task('local-verify', 'Verifies that the local deployment files correspond to the
       }
     }
     meta.settings.outputSelection = {}
-    const targets = Object.entries(meta.settings.compilationTarget)
+    const targets = Object.entries<string>(meta.settings.compilationTarget)
     for (const [key, value] of targets) {
       meta.settings.outputSelection[key] = {}
-      meta.settings.outputSelection[key][value as string] = ['evm.bytecode', 'evm.deployedBytecode', 'metadata']
+      meta.settings.outputSelection[key][value] = ['evm.deployedBytecode.object', 'evm.deployedBytecode.immutableReferences']
     }
     delete meta.settings.compilationTarget
     const compiled = solcjs.compile(JSON.stringify(meta))
     const output = JSON.parse(compiled)
     for (const [key, value] of targets) {
-      const compiledContract = output.contracts[key][value as string]
-      const onChainCode = await hre.ethers.provider.getCode(deployment.address)
+      const compiledContract = output.contracts[key][value]
+      const onChainCode = hre.ethers.getBytes(await hre.ethers.provider.getCode(deployment.address))
+      for (const references of Object.values<{ start: number; length: number }[]>(
+        compiledContract.evm.deployedBytecode.immutableReferences,
+      )) {
+        for (const { start, length } of references) {
+          onChainCode.fill(0, start, start + length)
+        }
+      }
       const onchainBytecodeHash = hre.ethers.keccak256(onChainCode)
       const localBytecodeHash = hre.ethers.keccak256(`0x${compiledContract.evm.deployedBytecode.object}`)
       const verifySuccess = onchainBytecodeHash === localBytecodeHash ? 'SUCCESS' : 'FAILURE'


### PR DESCRIPTION
Fixed #144 

This PR modifies the `local-verify` task to ignore immutable values comparing bytecode with compiler output. This was an issue as contracts were incorrectly marked as `FAILURE` during local verification despite matching bytecode.

```
$ npx hardhat local-verify --network localhost
Verification status for AddModulesLib: SUCCESS
Verification status for HariWillibaldToken: SUCCESS
Verification status for Safe4337Mock: SUCCESS
Verification status for Safe4337Module: SUCCESS
Verification status for SafeL2: SUCCESS
Verification status for SafeMock: SUCCESS
Verification status for SafeProxyFactory: SUCCESS
Verification status for TestEntryPoint: SUCCESS
```

Note that this PR explicitly choses ignore immutable values instead of trying to verify they would match. See https://github.com/safe-global/safe-contracts/pull/691 for additional discussion on why it was chosen this way (essentially, verifying `deployedBytecode` by simulating `bytecode` execution is non-trivial).