### PR TITLE
Created `onlySupportedEntryPoint(...)` modifier avoiding code redundancy

### DIFF
--- a/4337/contracts/Safe4337Module.sol
+++ b/4337/contracts/Safe4337Module.sol
@@ -56,7 +56,11 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @notice Validates a user operation provided by the entry point.
      * @inheritdoc IAccount
      */
-    function validateUserOp(UserOperation calldata userOp, bytes32, uint256 missingAccountFunds) external onlySupportedEntryPoint returns (uint256 validationData) {
+    function validateUserOp(
+        UserOperation calldata userOp,
+        bytes32,
+        uint256 missingAccountFunds
+    ) external onlySupportedEntryPoint returns (uint256 validationData) {
         address payable safeAddress = payable(userOp.sender);
         // The entry point address is appended to the calldata in `HandlerContext` contract
         // Because of this, the relayer may manipulate the entry point address, therefore we have to verify that

--- a/4337/contracts/Safe4337Module.sol
+++ b/4337/contracts/Safe4337Module.sol
@@ -48,7 +48,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @notice Validates the call is initiated by the entry point.
      */
     modifier onlySupportedEntryPoint() {
-        require(_msgSender() == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
+        _onlySupportedEntryPoint();
         _;
     }
 
@@ -188,5 +188,12 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         } catch {
             validationData = SIG_VALIDATION_FAILED;
         }
+    }
+
+    /**
+     * @notice Internal function to validates the call is initiated by the entry point.
+     */
+    function _onlySupportedEntryPoint() internal view {
+        require(_msgSender() == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
     }
 }

--- a/4337/contracts/Safe4337Module.sol
+++ b/4337/contracts/Safe4337Module.sol
@@ -48,7 +48,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @notice Validates the call is initiated by the entry point.
      */
     modifier onlySupportedEntryPoint() {
-        _onlySupportedEntryPoint();
+        require(_msgSender() == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
         _;
     }
 
@@ -188,12 +188,5 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         } catch {
             validationData = SIG_VALIDATION_FAILED;
         }
-    }
-
-    /**
-     * @notice Internal function to validates the call is initiated by the entry point.
-     */
-    function _onlySupportedEntryPoint() internal view {
-        require(_msgSender() == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
     }
 }

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -107,11 +107,18 @@ contract Safe4337Mock is SafeMock, IAccount {
 
     constructor(address entryPoint) SafeMock(entryPoint) {}
 
+    /**
+     * @notice Validates the call is initiated by the entry point.
+     */
+    modifier onlySupportedEntryPoint() {
+        require(msg.sender == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
+        _;
+    }
+
     /// @dev Validates user operation provided by the entry point
     /// @inheritdoc IAccount
-    function validateUserOp(UserOperation calldata userOp, bytes32, uint256 missingAccountFunds) external returns (uint256) {
+    function validateUserOp(UserOperation calldata userOp, bytes32, uint256 missingAccountFunds) external onlySupportedEntryPoint returns (uint256) {
         address entryPoint = msg.sender;
-        require(entryPoint == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
 
         _validateReplayProtection(userOp);
 
@@ -137,10 +144,7 @@ contract Safe4337Mock is SafeMock, IAccount {
     /// @param value Ether value of the user operation.
     /// @param data Data payload of the user operation.
     /// @param operation Operation type of the user operation.
-    function executeUserOp(address to, uint256 value, bytes memory data, uint8 operation) external {
-        address entryPoint = msg.sender;
-        require(entryPoint == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
-
+    function executeUserOp(address to, uint256 value, bytes memory data, uint8 operation) external onlySupportedEntryPoint {
         bool success;
         if (operation == 1) (success, ) = to.delegatecall(data);
         else (success, ) = to.call{value: value}(data);
@@ -153,10 +157,7 @@ contract Safe4337Mock is SafeMock, IAccount {
     /// @param value Ether value of the user operation.
     /// @param data Data payload of the user operation.
     /// @param operation Operation type of the user operation.
-    function executeUserOpWithErrorString(address to, uint256 value, bytes memory data, uint8 operation) external {
-        address entryPoint = msg.sender;
-        require(entryPoint == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
-
+    function executeUserOpWithErrorString(address to, uint256 value, bytes memory data, uint8 operation) external onlySupportedEntryPoint{
         bool success;
         bytes memory returnData;
         if (operation == 1) (success, returnData) = to.delegatecall(data);

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -111,7 +111,7 @@ contract Safe4337Mock is SafeMock, IAccount {
      * @notice Validates the call is initiated by the entry point.
      */
     modifier onlySupportedEntryPoint() {
-        require(msg.sender == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
+        _onlySupportedEntryPoint();
         _;
     }
 
@@ -272,5 +272,12 @@ contract Safe4337Mock is SafeMock, IAccount {
 
         // Check returned nonce against the user operation nonce
         require(safeNonce == userOp.nonce, "Invalid Nonce");
+    }
+
+    /**
+     * @notice Internal function to validates the call is initiated by the entry point.
+     */
+    function _onlySupportedEntryPoint() internal view {
+        require(msg.sender == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
     }
 }

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -111,7 +111,7 @@ contract Safe4337Mock is SafeMock, IAccount {
      * @notice Validates the call is initiated by the entry point.
      */
     modifier onlySupportedEntryPoint() {
-        _onlySupportedEntryPoint();
+        require(msg.sender == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
         _;
     }
 
@@ -272,12 +272,5 @@ contract Safe4337Mock is SafeMock, IAccount {
 
         // Check returned nonce against the user operation nonce
         require(safeNonce == userOp.nonce, "Invalid Nonce");
-    }
-
-    /**
-     * @notice Internal function to validates the call is initiated by the entry point.
-     */
-    function _onlySupportedEntryPoint() internal view {
-        require(msg.sender == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
     }
 }

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -117,7 +117,11 @@ contract Safe4337Mock is SafeMock, IAccount {
 
     /// @dev Validates user operation provided by the entry point
     /// @inheritdoc IAccount
-    function validateUserOp(UserOperation calldata userOp, bytes32, uint256 missingAccountFunds) external onlySupportedEntryPoint returns (uint256) {
+    function validateUserOp(
+        UserOperation calldata userOp,
+        bytes32,
+        uint256 missingAccountFunds
+    ) external onlySupportedEntryPoint returns (uint256) {
         address entryPoint = msg.sender;
 
         _validateReplayProtection(userOp);
@@ -157,7 +161,7 @@ contract Safe4337Mock is SafeMock, IAccount {
     /// @param value Ether value of the user operation.
     /// @param data Data payload of the user operation.
     /// @param operation Operation type of the user operation.
-    function executeUserOpWithErrorString(address to, uint256 value, bytes memory data, uint8 operation) external onlySupportedEntryPoint{
+    function executeUserOpWithErrorString(address to, uint256 value, bytes memory data, uint8 operation) external onlySupportedEntryPoint {
         bool success;
         bytes memory returnData;
         if (operation == 1) (success, returnData) = to.delegatecall(data);

--- a/4337/test/eip4337/EIP4337Module.spec.ts
+++ b/4337/test/eip4337/EIP4337Module.spec.ts
@@ -81,7 +81,9 @@ describe('Safe4337Module', () => {
         signature,
       })
 
-      await expect(entryPoint.executeUserOp(userOp, 0)).to.be.revertedWith('Unsupported execution function id')
+      const entryPointAddress = await ethers.getSigner(await entryPoint.getAddress())
+      const safeFromEntryPoint = safeModule.connect(entryPointAddress)
+      await expect(safeFromEntryPoint.validateUserOp.staticCall(userOp, ethers.ZeroHash, 0)).to.be.revertedWith('Unsupported execution function id')
     })
 
     it('should revert when not called from the trusted entrypoint', async () => {

--- a/4337/test/eip4337/EIP4337Module.spec.ts
+++ b/4337/test/eip4337/EIP4337Module.spec.ts
@@ -83,7 +83,9 @@ describe('Safe4337Module', () => {
 
       const entryPointAddress = await ethers.getSigner(await entryPoint.getAddress())
       const safeFromEntryPoint = safeModule.connect(entryPointAddress)
-      await expect(safeFromEntryPoint.validateUserOp.staticCall(userOp, ethers.ZeroHash, 0)).to.be.revertedWith('Unsupported execution function id')
+      await expect(safeFromEntryPoint.validateUserOp.staticCall(userOp, ethers.ZeroHash, 0)).to.be.revertedWith(
+        'Unsupported execution function id',
+      )
     })
 
     it('should revert when not called from the trusted entrypoint', async () => {

--- a/4337/test/eip4337/EIP4337Module.spec.ts
+++ b/4337/test/eip4337/EIP4337Module.spec.ts
@@ -81,7 +81,7 @@ describe('Safe4337Module', () => {
         signature,
       })
 
-      await expect(safeModule.validateUserOp(userOp, ethers.ZeroHash, 0)).to.be.revertedWith('Unsupported execution function id')
+      await expect(entryPoint.executeUserOp(userOp, 0)).to.be.revertedWith('Unsupported execution function id')
     })
 
     it('should revert when not called from the trusted entrypoint', async () => {


### PR DESCRIPTION
Closes #157

This PR removes the redundant code to check if the entry point contract is actually supported or not.