### PR TITLE
ERC-4337 Bundler Updates

### DIFF
--- a/4337/docker-compose.yaml
+++ b/4337/docker-compose.yaml
@@ -19,6 +19,6 @@ services:
       context: .
       dockerfile: docker/bundler/Dockerfile
     restart: always
-    command: ['--network', 'http://geth:8545']
+    command: ['--auto', '--network=http://geth:8545']
     ports:
       - 3000:3000

--- a/4337/docker/bundler/Dockerfile
+++ b/4337/docker/bundler/Dockerfile
@@ -1,7 +1,9 @@
 FROM docker.io/library/node:18
 
-RUN git clone --branch v0.6.0 https://github.com/eth-infinitism/bundler /src/bundler
+RUN git clone https://github.com/eth-infinitism/bundler /src/bundler
 WORKDIR /src/bundler
+# v0.6.1
+RUN git checkout 30dc20da10214415df60a5ee15a6bec0975c9af1
 
 RUN yarn && yarn preprocess
 ENTRYPOINT ["yarn", "bundler"]


### PR DESCRIPTION
This PR updates the reference bundler used for E2E tests:
- It uses a newer version of the bundler that includes the exception to associated storage access for staked factories (https://github.com/eth-infinitism/bundler/pull/127).
- Uses the `--auto` flag; by default, the bundler will wait for whichever comes first of 3 second or 10 user operations before submitting a bundle, with `--auto` flag, it submits the bundle right away

Notice that the E2E test run significantly faster with this change:

```
# before
  E2E - Local Bundler
    ✔ should deploy a new Safe and execute a transaction (3731ms)
    ✔ should execute a transaction for an exsiting Safe (2880ms)
# after
  E2E - Local Bundler
    ✔ should deploy a new Safe and execute a transaction (912ms)
    ✔ should execute a transaction for an exsiting Safe (628ms)
```