### PR TITLE
Send encoded Safe operation bytes to `checkSignatures` call

### DIFF
--- a/4337/contracts/Safe4337Module.sol
+++ b/4337/contracts/Safe4337Module.sol
@@ -151,7 +151,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         uint256 maxPriorityFeePerGas,
         uint96 signatureTimestamps,
         address entryPoint
-    ) public view returns (bytes memory) {
+    ) internal view returns (bytes memory) {
         bytes32 safeOperationHash = keccak256(
             abi.encode(
                 SAFE_OP_TYPEHASH,

--- a/4337/contracts/Safe4337Module.sol
+++ b/4337/contracts/Safe4337Module.sol
@@ -151,7 +151,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         uint256 maxPriorityFeePerGas,
         uint96 signatureTimestamps,
         address entryPoint
-    ) internal view returns (bytes memory) {
+    ) public view returns (bytes memory) {
         bytes32 safeOperationHash = keccak256(
             abi.encode(
                 SAFE_OP_TYPEHASH,

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -36,7 +36,8 @@ contract SafeMock {
         }
     }
 
-    function checkSignatures(bytes32 dataHash, bytes memory, bytes memory signature) public view {
+    function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signature) public view {
+        require(dataHash == keccak256(data), "Invalid data hash");
         uint8 v;
         bytes32 r;
         bytes32 s;

--- a/4337/src/utils/execution.ts
+++ b/4337/src/utils/execution.ts
@@ -43,12 +43,8 @@ export const signHash = async (signer: Signer, hash: string): Promise<SafeSignat
 
 export const buildSignatureBytes = (signatures: SafeSignature[], timestamps: BigNumberish = 0): string => {
   signatures.sort((left, right) => left.signer.toLowerCase().localeCompare(right.signer.toLowerCase()))
-  let signatureBytes = '0x'
-  for (const sig of signatures) {
-    signatureBytes += sig.data.slice(2)
-  }
-
-  const signatureWithTimestamps = ethers.solidityPacked(['uint96', 'bytes'], [timestamps.toString(), signatureBytes])
+  const signatureBytes = ethers.concat(signatures.map((signature) => signature.data))
+  const signatureWithTimestamps = ethers.solidityPacked(['uint96', 'bytes'], [timestamps, signatureBytes])
 
   return signatureWithTimestamps
 }

--- a/4337/src/utils/safe.ts
+++ b/4337/src/utils/safe.ts
@@ -1,4 +1,4 @@
-import { AddressLike, JsonRpcProvider, Provider, ethers } from 'ethers'
+import { AddressLike, JsonRpcProvider, Provider, Signer, ethers } from 'ethers'
 
 // Import from Safe contracts repo once fixed
 import { MetaTransaction, SafeSignature, buildSignatureBytes } from './execution'
@@ -269,6 +269,13 @@ export class Safe4337 {
 
     const code = await this.provider.getCode(this.address, 'latest')
     return code !== '0x'
+  }
+
+  async deploy(deployer: Signer): Promise<void> {
+    const initCode = this.getInitCode()
+    const factory = ethers.getAddress(ethers.dataSlice(initCode, 0, 20))
+    const initCallData = ethers.dataSlice(initCode, 20)
+    await deployer.sendTransaction({ to: factory, data: initCallData }).then((tx) => tx.wait())
   }
 
   getInitCode(): string {

--- a/4337/src/utils/userOp.ts
+++ b/4337/src/utils/userOp.ts
@@ -52,6 +52,10 @@ export const calculateSafeOperationHash = (eip4337ModuleAddress: string, safeOp:
   return ethers.TypedDataEncoder.hash({ chainId, verifyingContract: eip4337ModuleAddress }, EIP712_SAFE_OPERATION_TYPE, safeOp)
 }
 
+export const calculateSafeOperationData = (eip4337ModuleAddress: string, safeOp: SafeUserOperation, chainId: BigNumberish): string => {
+  return ethers.TypedDataEncoder.encode({ chainId, verifyingContract: eip4337ModuleAddress }, EIP712_SAFE_OPERATION_TYPE, safeOp)
+}
+
 export const signSafeOp = async (
   signer: Signer,
   moduleAddress: string,

--- a/4337/test/e2e/LocalBundler.spec.ts
+++ b/4337/test/e2e/LocalBundler.spec.ts
@@ -120,11 +120,7 @@ describe('E2E - Local Bundler', () => {
   it('should execute a transaction for an exsiting Safe', async () => {
     const { user, bundler, safe, validator, entryPoint, token } = await setupTests()
 
-    const initCode = safe.getInitCode()
-    const factory = ethers.getAddress(ethers.dataSlice(initCode, 0, 20))
-    const initCallData = ethers.dataSlice(initCode, 20)
-    await user.sendTransaction({ to: factory, data: initCallData }).then((tx) => tx.wait())
-
+    await safe.deploy(user)
     await token.transfer(safe.address, ethers.parseUnits('4.2', 18)).then((tx) => tx.wait())
     await user.sendTransaction({ to: safe.address, value: ethers.parseEther('0.5') }).then((tx) => tx.wait())
 

--- a/4337/test/eip4337/Safe4337Module.spec.ts
+++ b/4337/test/eip4337/Safe4337Module.spec.ts
@@ -5,7 +5,6 @@ import { getTestSafe, getSafe4337Module, getEntryPoint } from '../utils/setup'
 import { buildSignatureBytes, signHash } from '../../src/utils/execution'
 import {
   buildSafeUserOp,
-  calculateSafeOperationData,
   calculateSafeOperationHash,
   buildUserOperationFromSafeUserOperation,
   buildSafeUserOpTransaction,
@@ -35,38 +34,6 @@ describe('Safe4337Module', () => {
       safeModule,
       makeSafeModule,
     }
-  })
-
-  describe('getOperationData', () => {
-    it('should correctly calculate EIP-712 encoded data of the operation', async () => {
-      const { validator, safeModule, entryPoint } = await setupTests()
-
-      const safeAddress = ethers.hexlify(ethers.randomBytes(20))
-      const validAfter = Date.now() + 10000
-      const validUntil = validAfter + 10000000000
-      const packedSignatureTimestamps = encodeSignatureTimestamp(validUntil, validAfter)
-
-      const operation = buildSafeUserOp({
-        safe: safeAddress,
-        nonce: '0',
-        entryPoint: await entryPoint.getAddress(),
-        signatureTimestamps: packedSignatureTimestamps,
-      })
-      const operationData = await safeModule.getOperationData(
-        safeAddress,
-        operation.callData,
-        operation.nonce,
-        operation.preVerificationGas,
-        operation.verificationGasLimit,
-        operation.callGasLimit,
-        operation.maxFeePerGas,
-        operation.maxPriorityFeePerGas,
-        operation.signatureTimestamps,
-        operation.entryPoint,
-      )
-
-      expect(operationData).to.equal(calculateSafeOperationData(await validator.getAddress(), operation, await chainId()))
-    })
   })
 
   describe('getOperationHash', () => {


### PR DESCRIPTION
Fixes #160 

This PR fixes the `checkSignatures` call to the Safe to include both the Safe operation hash for recovery, but also the encoded operation bytes, which is required when using an ERC-1271 signer. In order to test this, the `SafeMock` now requires that `dataHash == keccak256(data)` and I added a unit test using a nested Safe set (note that this would require a staked paymaster to work with 4337 bundlers, but the test does check that the contract signatures works as expected).
