### PR TITLE
[4337] Separate Signature Fields for `validAfter` and `validUntil`

### DIFF
--- a/4337/src/utils/execution.ts
+++ b/4337/src/utils/execution.ts
@@ -41,10 +41,10 @@ export const signHash = async (signer: Signer, hash: string): Promise<SafeSignat
   }
 }
 
-export const buildSignatureBytes = (signatures: SafeSignature[], timestamps: BigNumberish = 0): string => {
+export const buildSignatureBytes = (signatures: SafeSignature[], validAfter: BigNumberish = 0, validUntil: BigNumberish = 0): string => {
   signatures.sort((left, right) => left.signer.toLowerCase().localeCompare(right.signer.toLowerCase()))
   const signatureBytes = ethers.concat(signatures.map((signature) => signature.data))
-  const signatureWithTimestamps = ethers.solidityPacked(['uint96', 'bytes'], [timestamps, signatureBytes])
+  const signatureWithTimestamps = ethers.solidityPacked(['uint48', 'uint48', 'bytes'], [validAfter ?? 0, validUntil ?? 0, signatureBytes])
 
   return signatureWithTimestamps
 }

--- a/4337/test/eip4337/ReferenceEntryPoint.spec.ts
+++ b/4337/test/eip4337/ReferenceEntryPoint.spec.ts
@@ -9,7 +9,6 @@ import {
   buildSafeUserOpTransaction,
   buildUserOperationFromSafeUserOperation,
   calculateSafeOperationData,
-  encodeSignatureTimestamp,
   signSafeOp,
 } from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
@@ -106,7 +105,6 @@ describe('Safe4337Module - Reference EntryPoint', () => {
     const now = await time.latest()
     const validAfter = now + 86400 // 1 day from now
     const validUntil = validAfter + 86400 // 1 day after validAfter
-    const signatureTimestamps = encodeSignatureTimestamp(validUntil, validAfter)
 
     if (!now) throw new Error("Failed to fetch the latest block's timestamp found")
 
@@ -124,11 +122,13 @@ describe('Safe4337Module - Reference EntryPoint', () => {
           await entryPoint.getAddress(),
           false,
           false,
-          signatureTimestamps,
+          validAfter,
+          validUntil,
         )
         const signature = buildSignatureBytes(
           [await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())],
-          signatureTimestamps,
+          validAfter,
+          validUntil,
         )
         return buildUserOperationFromSafeUserOperation({
           safeAddress: safe.address,

--- a/4337/test/eip4337/Safe4337Module.spec.ts
+++ b/4337/test/eip4337/Safe4337Module.spec.ts
@@ -5,13 +5,12 @@ import { getTestSafe, getSafe4337Module, getEntryPoint } from '../utils/setup'
 import { buildSignatureBytes, signHash } from '../../src/utils/execution'
 import {
   buildSafeUserOp,
-  calculateSafeOperationHash,
-  buildUserOperationFromSafeUserOperation,
   buildSafeUserOpTransaction,
-  encodeSignatureTimestamp,
+  buildUserOperationFromSafeUserOperation,
+  calculateSafeOperationHash,
   packValidationData,
 } from '../../src/utils/userOp'
-import { chainId } from '../utils/encoding'
+import { chainId, timestamp } from '../utils/encoding'
 
 describe('Safe4337Module', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
@@ -41,15 +40,15 @@ describe('Safe4337Module', () => {
       const { validator, safeModule, entryPoint } = await setupTests()
 
       const safeAddress = ethers.hexlify(ethers.randomBytes(20))
-      const validAfter = Date.now() + 10000
+      const validAfter = (await timestamp()) + 10000
       const validUntil = validAfter + 10000000000
-      const packedSignatureTimestamps = encodeSignatureTimestamp(validUntil, validAfter)
 
       const operation = buildSafeUserOp({
         safe: safeAddress,
         nonce: '0',
         entryPoint: await entryPoint.getAddress(),
-        signatureTimestamps: packedSignatureTimestamps,
+        validAfter,
+        validUntil,
       })
       const operationHash = await safeModule.getOperationHash(
         safeAddress,
@@ -60,8 +59,8 @@ describe('Safe4337Module', () => {
         operation.callGasLimit,
         operation.maxFeePerGas,
         operation.maxPriorityFeePerGas,
-        operation.signatureTimestamps,
-        operation.entryPoint,
+        operation.validAfter,
+        operation.validUntil,
       )
 
       expect(operationHash).to.equal(calculateSafeOperationHash(await validator.getAddress(), operation, await chainId()))
@@ -141,7 +140,6 @@ describe('Safe4337Module', () => {
 
       const validAfter = BigInt(ethers.hexlify(ethers.randomBytes(3)))
       const validUntil = validAfter + BigInt(ethers.hexlify(ethers.randomBytes(3)))
-      const packedSignatureTimestamps = encodeSignatureTimestamp(validUntil, validAfter)
 
       const safeOp = buildSafeUserOpTransaction(
         await safeModule.getAddress(),
@@ -152,11 +150,12 @@ describe('Safe4337Module', () => {
         await entryPoint.getAddress(),
         false,
         false,
-        packedSignatureTimestamps,
+        validAfter,
+        validUntil,
       )
 
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
-      const signature = buildSignatureBytes([await signHash(user, safeOpHash)], safeOp.signatureTimestamps)
+      const signature = buildSignatureBytes([await signHash(user, safeOpHash)], validAfter, validUntil)
       const userOp = buildUserOperationFromSafeUserOperation({
         safeAddress: await safeModule.getAddress(),
         safeOp,

--- a/4337/test/utils/encoding.ts
+++ b/4337/test/utils/encoding.ts
@@ -17,3 +17,11 @@ export const encodeTransfer = (target: string, amount: string | number): string 
 export const chainId = async () => {
   return (await ethers.provider.getNetwork()).chainId
 }
+
+export const timestamp = async () => {
+  const block = await ethers.provider.getBlock('latest')
+  if (block === null) {
+    throw new Error('missing latest block???')
+  }
+  return block.timestamp
+}


### PR DESCRIPTION
Follow up to #143 and #156

This PR refactors signature validation to use the immutable `SUPPORTED_ENTRYPOINT` value instead of passing it into various functions. This has the benefit of freeing up a stack slot for an additional variable. This means that we can now sign `validAfter` and `validUntil` as separate fields in our `SafeOp` struct (which should provide a nicer user experience for signing and be less cryptic than using a “signatureTimestamps” field that combines both values).

The caveat is that `getOperationHash` is tied to the module’s supported `EntryPoint` value, but IMO this makes more sense that what we had before, as signatures for other `EntryPoint`s are useless to it anyway.

Additionally, in theory, we don’t need to include the `entryPoint` in the signature, since it is implied by the `verifyingContract` address of the ERC-4337 module, seeing as `SUPPORTED_ENTRYPOINT` is an immutable. However, I decided to leave it in, the rationale being that it adds additional information to the user signature and improves UX around collecting EIP-712 signatures.

I added validity timestamps to the user operation in one of the E2E tests for better coverage.
