### PR TITLE
Check paymaster and data as well

### DIFF
--- a/4337/contracts/Safe4337Module.sol
+++ b/4337/contracts/Safe4337Module.sol
@@ -34,7 +34,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
 
     bytes32 private constant SAFE_OP_TYPEHASH =
         keccak256(
-            "SafeOp(address safe,bytes callData,uint256 nonce,uint256 preVerificationGas,uint256 verificationGasLimit,uint256 callGasLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,address entryPoint)"
+            "SafeOp(address safe,bytes callData,uint256 nonce,uint256 preVerificationGas,uint256 verificationGasLimit,uint256 callGasLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,bytes paymasterAndData,address entryPoint)"
         );
 
     address public immutable SUPPORTED_ENTRYPOINT;
@@ -128,6 +128,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @param callGasLimit Gas available during the execution of the call.
      * @param maxFeePerGas Max fee per gas.
      * @param maxPriorityFeePerGas Max priority fee per gas.
+     * @param paymasterAndData Paymaster address and data.
      * @param entryPoint Address of the entry point.
      * @return Operation hash.
      */
@@ -140,6 +141,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         uint256 callGasLimit,
         uint256 maxFeePerGas,
         uint256 maxPriorityFeePerGas,
+        bytes memory paymasterAndData,
         address entryPoint
     ) external view returns (bytes32) {
         return
@@ -153,6 +155,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
                     callGasLimit,
                     maxFeePerGas,
                     maxPriorityFeePerGas,
+                    paymasterAndData,
                     entryPoint
                 )
             );
@@ -174,6 +177,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
             userOp.callGasLimit,
             userOp.maxFeePerGas,
             userOp.maxPriorityFeePerGas,
+            userOp.paymasterAndData,
             entryPoint
         );
         bytes32 operationHash = keccak256(operationData);
@@ -195,6 +199,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @param callGasLimit Gas available during the execution of the call.
      * @param maxFeePerGas Max fee per gas.
      * @param maxPriorityFeePerGas Max priority fee per gas.
+     * @param paymasterAndData Paymaster address and data.
      * @param entryPoint Address of the entry point.
      * @return Operation bytes.
      */
@@ -207,6 +212,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         uint256 callGasLimit,
         uint256 maxFeePerGas,
         uint256 maxPriorityFeePerGas,
+        bytes memory paymasterAndData,
         address entryPoint
     ) internal view returns (bytes memory) {
         bytes32 safeOperationHash = keccak256(
@@ -220,6 +226,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
                 callGasLimit,
                 maxFeePerGas,
                 maxPriorityFeePerGas,
+                keccak256(paymasterAndData),
                 entryPoint
             )
         );

--- a/4337/contracts/test/SafeMock.sol
+++ b/4337/contracts/test/SafeMock.sol
@@ -107,7 +107,7 @@ contract Safe4337Mock is SafeMock, IAccount {
 
     bytes32 private constant SAFE_OP_TYPEHASH =
         keccak256(
-            "SafeOp(address safe,bytes callData,uint256 nonce,uint256 preVerificationGas,uint256 verificationGasLimit,uint256 callGasLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,address entryPoint)"
+            "SafeOp(address safe,bytes callData,uint256 nonce,uint256 preVerificationGas,uint256 verificationGasLimit,uint256 callGasLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,bytes paymasterAndData,address entryPoint)"
         );
 
     constructor(address entryPoint) SafeMock(entryPoint) {}
@@ -173,26 +173,16 @@ contract Safe4337Mock is SafeMock, IAccount {
         return keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, block.chainid, this));
     }
 
-    /// @dev Returns the bytes that are hashed to be signed by owners.
-    /// @param safe Safe address
-    /// @param callData Call data
-    /// @param nonce Nonce of the operation
-    /// @param preVerificationGas Gas required for pre-verification (e.g. for EOA signature verification)
-    /// @param verificationGasLimit Gas required for verification
-    /// @param callGasLimit Gas available during the execution of the call
-    /// @param maxFeePerGas Max fee per gas
-    /// @param maxPriorityFeePerGas Max priority fee per gas
-    /// @param entryPoint Address of the entry point
-    /// @return Operation hash bytes
     function encodeOperationData(
         address safe,
-        bytes calldata callData,
+        bytes memory callData,
         uint256 nonce,
         uint256 preVerificationGas,
         uint256 verificationGasLimit,
         uint256 callGasLimit,
         uint256 maxFeePerGas,
         uint256 maxPriorityFeePerGas,
+        bytes memory paymasterAndData,
         address entryPoint
     ) public view returns (bytes memory) {
         bytes32 safeOperationHash = keccak256(
@@ -206,6 +196,7 @@ contract Safe4337Mock is SafeMock, IAccount {
                 callGasLimit,
                 maxFeePerGas,
                 maxPriorityFeePerGas,
+                keccak256(paymasterAndData),
                 entryPoint
             )
         );
@@ -215,13 +206,14 @@ contract Safe4337Mock is SafeMock, IAccount {
 
     function getOperationHash(
         address safe,
-        bytes calldata callData,
+        bytes memory callData,
         uint256 nonce,
         uint256 preVerificationGas,
         uint256 verificationGasLimit,
         uint256 callGasLimit,
         uint256 maxFeePerGas,
         uint256 maxPriorityFeePerGas,
+        bytes memory paymasterAndData,
         address entryPoint
     ) public view returns (bytes32) {
         return
@@ -235,6 +227,7 @@ contract Safe4337Mock is SafeMock, IAccount {
                     callGasLimit,
                     maxFeePerGas,
                     maxPriorityFeePerGas,
+                    paymasterAndData,
                     entryPoint
                 )
             );
@@ -257,6 +250,7 @@ contract Safe4337Mock is SafeMock, IAccount {
             userOp.callGasLimit,
             userOp.maxFeePerGas,
             userOp.maxPriorityFeePerGas,
+            userOp.paymasterAndData,
             entryPoint
         );
         bytes32 operationHash = keccak256(operationData);

--- a/4337/src/utils/userOp.ts
+++ b/4337/src/utils/userOp.ts
@@ -28,11 +28,11 @@ export interface SafeUserOperation {
   callGasLimit: string
   maxFeePerGas: string
   maxPriorityFeePerGas: string
+  paymasterAndData: string
   entryPoint: string
 }
 
 export const EIP712_SAFE_OPERATION_TYPE = {
-  // "SafeOp(address safe,bytes callData,uint256 nonce,uint256 preVerificationGas,uint256 verificationGasLimit,uint256 callGasLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,address entryPoint)"
   SafeOp: [
     { type: 'address', name: 'safe' },
     { type: 'bytes', name: 'callData' },
@@ -42,6 +42,7 @@ export const EIP712_SAFE_OPERATION_TYPE = {
     { type: 'uint256', name: 'callGasLimit' },
     { type: 'uint256', name: 'maxFeePerGas' },
     { type: 'uint256', name: 'maxPriorityFeePerGas' },
+    { type: 'bytes', name: 'paymasterAndData' },
     { type: 'address', name: 'entryPoint' },
   ],
 }
@@ -80,6 +81,7 @@ export const buildSafeUserOp = (template: OptionalExceptFor<SafeUserOperation, '
     callGasLimit: template.callGasLimit || '2000000',
     maxFeePerGas: template.maxFeePerGas || '10000000000',
     maxPriorityFeePerGas: template.maxPriorityFeePerGas || '10000000000',
+    paymasterAndData: template.paymasterAndData || '0x',
   }
 }
 

--- a/4337/test/eip4337/EIP4337ModuleExisting.spec.ts
+++ b/4337/test/eip4337/EIP4337ModuleExisting.spec.ts
@@ -41,6 +41,7 @@ describe('Safe4337Module - Existing Safe', () => {
         operation.callGasLimit,
         operation.maxFeePerGas,
         operation.maxPriorityFeePerGas,
+        operation.paymasterAndData,
         operation.entryPoint,
       )
 

--- a/4337/test/eip4337/EIP4337Safe.spec.ts
+++ b/4337/test/eip4337/EIP4337Safe.spec.ts
@@ -41,6 +41,7 @@ describe('Safe4337Mock', () => {
         operation.callGasLimit,
         operation.maxFeePerGas,
         operation.maxPriorityFeePerGas,
+        operation.paymasterAndData,
         operation.entryPoint,
       )
 


### PR DESCRIPTION
This PR includes the paymaster and data in the `SafeOp` signature. This is still a draft since this changes the signature scheme, so it would imply that signatures would be different, in which case we can include the `valid*` fields already.