### PR TITLE
Document Deployment Process and Changelog

### DIFF
--- a/4337/CHANGELOG.md
+++ b/4337/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+This changelog only contains changes starting from version 0.2.0
+
+# Version 0.2.0
+
+## Compiler settings
+
+Solidity compiler: [0.8.23](https://github.com/ethereum/solidity/releases/tag/v0.8.23)
+
+Solidity optimizer: enabled with 10.000.000 runs
+
+## Expected addresses
+
+-   `AddModulesLib` at `0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb`
+-   `Safe4337Module` at `0xa581c4A4DB7175302464fF3C06380BC3270b4037`
+
+## Changes
+
+### Security Fixes
+
+- Sign Full User Operation Data ([#177](https://github.com/safe-global/safe-modules/pull/177))
+
+### Compatibility Fixes
+
+- Send encoded Safe operation bytes to `checkSignatures` call ([#165](https://github.com/safe-global/safe-modules/pull/165))
+- Fix Revert message propagation ([#163](https://github.com/safe-global/safe-modules/pull/163))
+
+### General
+
+- Support `validAfter` and `validUntil` timestamps ([#156](https://github.com/safe-global/safe-modules/pull/156))

--- a/4337/CHANGELOG.md
+++ b/4337/CHANGELOG.md
@@ -12,8 +12,8 @@ Solidity optimizer: enabled with 10.000.000 runs
 
 ## Expected addresses
 
--   `AddModulesLib` at `0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb`
--   `Safe4337Module` at `0xa581c4A4DB7175302464fF3C06380BC3270b4037`
+- `AddModulesLib` at `0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb`
+- `Safe4337Module` at `0xa581c4A4DB7175302464fF3C06380BC3270b4037`
 
 ## Changes
 

--- a/4337/README.md
+++ b/4337/README.md
@@ -154,6 +154,12 @@ docker compose up -d
 npm run test:e2e
 ```
 
+### Deployments
+
+A collection of the different Safe 4337 modules deployments and their addresses can be found in the [Safe module deployments](https://github.com/safe-global/safe-modules-deployments) repository.
+
+To add support for a new network follow the steps of the Deploy section and create a PR in the [Safe module deployments](https://github.com/safe-global/safe-modules-deployments) repository.
+
 ### Deploy
 
 > :warning: **Make sure to use the correct commit when deploying the contracts.** Any change (even comments) within the contract files will result in different addresses. The tagged versions used by the Safe team can be found in the [releases](https://github.com/safe-modules/releases).


### PR DESCRIPTION
This PR adds a deployment documentation section similar to the [Safe contracts](https://github.com/safe-global/safe-contracts#deployments) and a changelog file containing the important contract changes.

Note that for the changelog, I only include the PR title and a link, as the relevant context can be found there (and didn't want to duplicate it in the CHANGELOG file).