### PR TITLE
Update `deploy` section in the readme

### DIFF
--- a/4337/README.md
+++ b/4337/README.md
@@ -156,9 +156,9 @@ npm run test:e2e
 
 ### Deploy
 
-> :warning: **Make sure to use the correct commit when deploying the contracts.** Any change (even comments) within the contract files will result in different addresses. The tagged versions used by the Safe team can be found in the [releases](https://github.com/safe-modules/releases).
+> :warning: **Make sure to use the correct commit when deploying the contracts.** Any change (even comments) within the contract files will result in different addresses. The tagged versions used by the Safe team can be found in the [releases](https://github.com/safe-global/safe-modules/releases).
 
-This will deploy the contracts deterministically and verify the contracts on etherscan using [Solidity 0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6) by default.
+This will deploy the contracts deterministically and verify the contracts on etherscan and sourcify.
 
 Preparation:
 


### PR DESCRIPTION
1. Fix the dead link for the releases page (follow-up: do tags like 0.1.0 work well for a monorepo?)
2. Remove the compiler settings from the section; we have a separate section about compiler settings.