### PR TITLE
Fix Disclaimer Warning Icons

### DIFF
--- a/4337/docs/v0.1.0/audit.md
+++ b/4337/docs/v0.1.0/audit.md
@@ -1,4 +1,4 @@
-**:warning: This version contains known issues and should not be used. :warning:**
+**⚠️ This version contains known issues and should not be used. ⚠️**
 
 # Audit Results
 


### PR DESCRIPTION
This PR just updates the disclaimer in the v0.1.0 audit file to correctly render its ⚠️ icons.

It looks like VS Code renders markdown slightly differently than GH.