### PR TITLE
Vendor: Update vendored FCL code

### DIFF
--- a/4337/contracts/test/FCL/FCL_Webauthn.sol
+++ b/4337/contracts/test/FCL/FCL_Webauthn.sol
@@ -93,13 +93,26 @@ library FCL_WebAuthn {
         uint256[2] calldata rs,
         uint256[2] calldata Q
     ) internal view returns (bool) {
+        return checkSignature(authenticatorData, authenticatorDataFlagMask, clientData, clientChallenge, clientChallengeDataOffset, rs, Q[0], Q[1]);
+    }
+
+    function  checkSignature (
+        bytes calldata authenticatorData,
+        bytes1 authenticatorDataFlagMask,
+        bytes calldata clientData,
+        bytes32 clientChallenge,
+        uint256 clientChallengeDataOffset,
+        uint256[2] calldata rs,
+        uint256 Qx,
+        uint256 Qy
+    ) internal view returns (bool) {
         // Let the caller check if User Presence (0x01) or User Verification (0x04) are set
 
         bytes32 message = FCL_WebAuthn.WebAuthn_format(
             authenticatorData, authenticatorDataFlagMask, clientData, clientChallenge, clientChallengeDataOffset, rs
         );
 
-        bool result = FCL_ecdsa_utils.ecdsa_verify(message, rs, Q);
+        bool result = FCL_ecdsa_utils.ecdsa_verify(message, rs, Qx, Qy);
 
         return result;
     }

--- a/4337/contracts/test/FCL/FCL_ecdsa_utils.sol
+++ b/4337/contracts/test/FCL/FCL_ecdsa_utils.sol
@@ -35,14 +35,12 @@ library FCL_ecdsa_utils {
      * @dev ECDSA verification, given , signature, and public key.
      */
 
-    function ecdsa_verify(bytes32 message, uint256[2] calldata rs, uint256[2] calldata Q) internal view returns (bool) {
+    function ecdsa_verify(bytes32 message, uint256[2] calldata rs, uint256 Qx, uint256 Qy) internal view returns (bool) {
         uint256 r = rs[0];
         uint256 s = rs[1];
         if (r == 0 || r >= FCL_Elliptic_ZZ.n || s == 0 || s >= FCL_Elliptic_ZZ.n) {
             return false;
         }
-        uint256 Qx = Q[0];
-        uint256 Qy = Q[1];
         if (!FCL_Elliptic_ZZ.ecAff_isOnCurve(Qx, Qy)) {
             return false;
         }
@@ -58,6 +56,10 @@ library FCL_ecdsa_utils {
         
        
         return x1 == 0;
+    }
+
+    function ecdsa_verify(bytes32 message, uint256[2] calldata rs, uint256[2] calldata Q) internal view returns (bool) {
+        return ecdsa_verify(message, rs, Q[0], Q[1]);
     }
 
     function ec_recover_r1(uint256 h, uint256 v, uint256 r, uint256 s) internal view returns (address)

--- a/4337/contracts/test/FCL/FCL_elliptic.sol
+++ b/4337/contracts/test/FCL/FCL_elliptic.sol
@@ -359,7 +359,12 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
             if (scalar_u == 0 && scalar_v == 0) return 0;
 
             (H0, H1) = ecAff_add(gx, gy, Q0, Q1); 
+            if((H0==0)&&(H1==0))//handling Q=-G
+            {
+                scalar_u=addmod(scalar_u, n-scalar_v, n);
+                scalar_v=0;
 
+            }
             assembly {
                 for { let T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } eq(T4, 0) {
                     index := sub(index, 1)
@@ -442,12 +447,10 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
                                 T3 := mulmod(X, T2, p) // S = X1*V
 
                                 T1 := mulmod(T1, T2, p) // W=UV
-                                y2 := addmod(X, zz, p)  //X+ZZ
-                                let TT1 := addmod(X, sub(p, zz), p) //X-ZZ
-                                y2 := mulmod(y2, TT1, p) //(X-ZZ)(X+ZZ)
-                                T4 := mulmod(3, y2, p) //M
+                                y2 := mulmod(addmod(X, zz, p), addmod(X, sub(p, zz), p), p) //(X-ZZ)(X+ZZ)
+                                T4 := mulmod(3, y2, p) //M=3*(X-ZZ)(X+ZZ)
 
-                                zzz := mulmod(TT1, zzz, p) //zzz3=W*zzz1
+                                zzz := mulmod(T1, zzz, p) //zzz3=W*zzz1
                                 zz := mulmod(T2, zz, p) //zz3=V*ZZ1, V free
 
                                 X := addmod(mulmod(T4, T4, p), mulmod(minus_2, T3, p), p) //X3=M^2-2S

--- a/4337/contracts/test/FCL/VERSION.md
+++ b/4337/contracts/test/FCL/VERSION.md
@@ -1,1 +1,1 @@
-The sources in this directory were vendored from the [`FreshCryptoLib` repository at commit `e2830cb`](https://github.com/rdubois-crypto/FreshCryptoLib/tree/e2830cb5d7b0f6ae35b5800287c0f5c92388070b).
+The sources in this directory were vendored from the [`FreshCryptoLib` repository at commit `ee7bd6f`](https://github.com/rdubois-crypto/FreshCryptoLib/tree/ee7bd6f2ebf72aebe0b2eda6caf7b8d2573f31c9).


### PR DESCRIPTION
This PR:
- Updates the vendored FCL code with elliptic curve math fixes by Nick and minor solidity improvement we proposed converting the public key from `uint256[2] calldata` to two separate `uint256` variables
Includes:
- https://github.com/rdubois-crypto/FreshCryptoLib/pull/56
- https://github.com/rdubois-crypto/FreshCryptoLib/pull/52
- https://github.com/rdubois-crypto/FreshCryptoLib/pull/48