### PR TITLE
Implement WebAuthn Shim for Passkeys tests

### DIFF
--- a/4337/.solhintignore
+++ b/4337/.solhintignore
@@ -1,0 +1,1 @@
+contracts/test/FCL/

--- a/4337/package-lock.json
+++ b/4337/package-lock.json
@@ -16,6 +16,7 @@
         "@noble/curves": "^1.3.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.0",
+        "@simplewebauthn/server": "^8.3.5",
         "@types/chai": "^4.3.11",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.9.4",
@@ -98,6 +99,84 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.1.1.tgz",
+      "integrity": "sha512-blVBy5MXz6m36Vx0DfLd7PChOQKEs8lK2bD1WJn/vVgG4FXZiZmZb2GECHFvVPA5T7OnODd9xZiL3nMCv6QUhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.1.1.tgz",
+      "integrity": "sha512-h6KFOzqk8jXTvkOftyRIWGrd7sKQzQv2jVdTL9nKSf3D2drCvQB/LHUxAOpPXo3pv2clDtKs3xnHalpEh3rDsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.1.1.tgz",
+      "integrity": "sha512-ds0uikdcIGUjPyraV4oJqyVE5gl/qYBpa/Wnh6l6xLE2lj/hwnjT2XcZCChdXwW/YFZ1LUHs6waoYN8PmK0nKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.1.1.tgz",
+      "integrity": "sha512-SxAaRcYf8S0QHaMc7gvRSiTSr7nUYMqbUdErBEu+HYA4Q6UNydx1VwFE68hGcp1qvxcy9yT5U7gA+a5XikfwSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.1.1.tgz",
+      "integrity": "sha512-GVK+8fNIE9lJQHAlhOROYiI0Yd4bAZ4u++C2ZjlkS3YmO6hi+FUxe6Dqm+OKWTcMpL/l71N6CQAmaRcb4zyJuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.1.1.tgz",
+      "integrity": "sha512-2Niq1C41dCRIDeD8LddiH+mxGlO7HJ612Ll3D/E73ZWBmycued+8ghTr/Ho3CMOWPUEr08XtyBMVXAjqF+TcKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@chainsafe/as-sha256": {
       "version": "0.3.1",
@@ -997,6 +1076,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "dev": true
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -1776,6 +1861,95 @@
       "integrity": "sha512-bv2sdS6LKqVVMLI5+zqnNrNU/CA+6z6CmwFXm/MzmOPBRSO5reEJN7z0Gbzvs0/bv/MZZXNklubpwy3v2+azsw==",
       "dev": true
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.3.10.tgz",
+      "integrity": "sha512-z9Rx9cFJv7UUablZISe7uksNbFJCq13hO0yEAOoIpAymALTLlvUOSLnGiQS7okPaM5dP42oTLhezH6XDXRXjGw==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@peculiar/asn1-android/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.8.tgz",
+      "integrity": "sha512-Ah/Q15y3A/CtxbPibiLM/LKcMbnLTdUdLHUgdpB5f60sSvGkXzxJCu5ezGTFHogZXWNX3KSmYqilCrfdmBc6pQ==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.8.tgz",
+      "integrity": "sha512-ES/RVEHu8VMYXgrg3gjb1m/XG0KJWnV4qyZZ7mAg7rrF3VTmRbLxO8mk+uy0Hme7geSMebp+Wvi2U6RLLEs12Q==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
+      "dev": true,
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.8.tgz",
+      "integrity": "sha512-voKxGfDU1c6r9mKiN5ZUsZWh3Dy1BABvTM3cimf0tztNwyMJPhiXY94eRTgsMQe6ViLfT6EoXxkWVzcm3mFAFw==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "asn1js": "^3.0.5",
+        "ipaddr.js": "^2.1.0",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/@pkgr/utils": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
@@ -2051,6 +2225,32 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-8.3.5.tgz",
+      "integrity": "sha512-Y6FkggTkzUdPk3cG3LLCiv7rqPQ3QI7g//RU9937G1pxogChvx12Y7/AZdWeMoeP+LFl0fPpdc1bIE0etJOxGA==",
+      "dev": true,
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@peculiar/asn1-android": "^2.3.6",
+        "@peculiar/asn1-ecc": "^2.3.6",
+        "@peculiar/asn1-rsa": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "@simplewebauthn/typescript-types": "^8.3.4",
+        "cbor-x": "^1.5.2",
+        "cross-fetch": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/typescript-types": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/typescript-types/-/typescript-types-8.3.4.tgz",
+      "integrity": "sha512-38xtca0OqfRVNloKBrFB5LEM6PN5vzFbJG6rAutPVrtGHFYxPdiV3btYWq0eAZAZmP+dqFPYJxJWeJrGfmYHng==",
       "dev": true
     },
     "node_modules/@sindresorhus/is": {
@@ -2979,6 +3179,20 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dev": true,
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -3377,6 +3591,37 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/cbor-extract": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.1.1.tgz",
+      "integrity": "sha512-1UX977+L+zOJHsp0mWFG13GLwO6ucKgSmSW6JTl8B9GUvACvHeIVpFqhU92299Z6PfD09aTXDell5p+lp1rUFA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.0.3"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.1.1",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-arm": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.1.1",
+        "@cbor-extract/cbor-extract-linux-x64": "2.1.1",
+        "@cbor-extract/cbor-extract-win32-x64": "2.1.1"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.6.tgz",
+      "integrity": "sha512-+TXdnDNdr8JH5GQRoAhjdT/5s5N+b71s2Nz8DpDRyuWx0uzMj8JTR3AqqMTBO/1HtUBHZpmK1enD2ViXFx0Nug==",
+      "dev": true,
+      "optionalDependencies": {
+        "cbor-extract": "^2.1.1"
       }
     },
     "node_modules/chai": {
@@ -3845,6 +4090,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6637,6 +6891,15 @@
         "fp-ts": "^1.0.0"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -7869,6 +8132,26 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
@@ -7878,6 +8161,18 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/nofilter": {
@@ -8533,6 +8828,30 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/qs": {
@@ -10328,6 +10647,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -10936,6 +11261,22 @@
         "@noble/hashes": "1.3.1",
         "@scure/bip32": "1.3.1",
         "@scure/bip39": "1.2.1"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/4337/package-lock.json
+++ b/4337/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@account-abstraction/contracts": "^0.6.0",
+        "@noble/curves": "^1.3.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.0",
         "@types/chai": "^4.3.11",
@@ -21,6 +22,7 @@
         "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^6.12.0",
         "@typescript-eslint/parser": "^6.12.0",
+        "cbor": "^9.0.1",
         "debug": "^4.3.4",
         "dotenv": "^16.0.1",
         "eslint": "^8.54.0",
@@ -1100,11 +1102,24 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dev": true,
       "dependencies": {
-        "@noble/hashes": "1.3.2"
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1559,6 +1574,19 @@
       },
       "peerDependencies": {
         "hardhat": "^2.0.4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
@@ -3340,16 +3368,15 @@
       }
     },
     "node_modules/cbor": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
-      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.1.tgz",
+      "integrity": "sha512-/TQOWyamDxvVIv+DY9cOLNuABkoyz8K/F3QE56539pGVYohx0+MEA1f4lChFTX79dBTBS7R1PF6ovH7G+VtBfQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "nofilter": "^3.1.0"
       },
       "engines": {
-        "node": ">=12.19"
+        "node": ">=16"
       }
     },
     "node_modules/chai": {
@@ -5045,6 +5072,17 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ethers/node_modules/@types/node": {
@@ -7847,7 +7885,6 @@
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
       "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12.19"
       }

--- a/4337/package.json
+++ b/4337/package.json
@@ -49,6 +49,7 @@
     "@noble/curves": "^1.3.0",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@openzeppelin/contracts": "^5.0.0",
+    "@simplewebauthn/server": "^8.3.5",
     "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.9.4",

--- a/4337/package.json
+++ b/4337/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@account-abstraction/contracts": "^0.6.0",
+    "@noble/curves": "^1.3.0",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@openzeppelin/contracts": "^5.0.0",
     "@types/chai": "^4.3.11",
@@ -54,6 +55,7 @@
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",
+    "cbor": "^9.0.1",
     "debug": "^4.3.4",
     "dotenv": "^16.0.1",
     "eslint": "^8.54.0",

--- a/4337/test/utils/webauthn.ts
+++ b/4337/test/utils/webauthn.ts
@@ -1,0 +1,231 @@
+/**
+ * This module provides a minimal shim to emulate the Web Authentication API implemented in browsers. This allows us to
+ * write tests where we create and authenticate WebAuthn credentials that are verified on-chain.
+ *
+ * This implementation is inspired by software authenticators found in the Awesome WebAuthn list [1].
+ *
+ * [1]: <https://github.com/herrjemand/awesome-webauthn#software-authenticators>
+ */
+
+import { p256 } from '@noble/curves/p256'
+import { ethers } from 'hardhat'
+import CBOR from 'cbor'
+
+export interface CredentialCreationOptions {
+  publicKey: PublicKeyCredentialCreationOptions
+}
+
+/**
+ * Public key credetial creation options, restricted to a subset of options that this module supports.
+ * See <https://w3c.github.io/webauthn/#dictionary-makecredentialoptions>.
+ */
+export interface PublicKeyCredentialCreationOptions {
+  rp: { id: string; name: string }
+  user: { id: Uint8Array; displayName: string; name: string }
+  challenge: Uint8Array
+  pubKeyCredParams: [{ type: 'public-key'; alg: -7 }]
+  timeout: undefined
+  excludeCredentials: undefined
+  authenticatorSelection: undefined
+  hints: undefined
+  attestation?: 'none'
+  attestationFormats: undefined
+  extensions: undefined
+}
+
+export interface CredentialRequestOptions {
+  publicKey: PublicKeyCredentialRequestOptions
+}
+
+/**
+ * Public key credetial request options, restricted to a subset of options that this module supports.
+ * See <https://w3c.github.io/webauthn/#dictionary-assertion-options>.
+ */
+export interface PublicKeyCredentialRequestOptions {
+  challenge: Uint8Array
+  timeout: undefined
+  rpId: string
+  allowCredentials: [
+    {
+      type: 'public-key'
+      id: Uint8Array
+      transports: undefined
+    },
+  ]
+  userVerification: undefined
+  hints: undefined
+  attestation?: 'none'
+  attestationFormats: undefined
+  extensions: undefined
+}
+
+/**
+ * A created public key credential. See <https://w3c.github.io/webauthn/#iface-pkcredential>.
+ */
+export interface PublicKeyCredential<AuthenticatorResponse> {
+  type: 'public-key'
+  id: string
+  rawId: ArrayBuffer
+  response: AuthenticatorResponse
+}
+
+/**
+ * The authenticator's response to a client’s request for the creation of a new public key credential.
+ * See <https://w3c.github.io/webauthn/#iface-authenticatorattestationresponse>.
+ */
+export interface AuthenticatorAttestationResponse {
+  clientDataJSON: ArrayBuffer
+  attestationObject: ArrayBuffer
+}
+
+/**
+ * The authenticator's response to a client’s request generation of a new authentication assertion given the WebAuthn Relying Party's challenge.
+ * See <https://w3c.github.io/webauthn/#iface-authenticatorassertionresponse>.
+ */
+export interface AuthenticatorAssertionResponse {
+  clientDataJSON: ArrayBuffer
+  authenticatorData: ArrayBuffer
+  signature: ArrayBuffer
+  userHandle: ArrayBuffer
+}
+
+class Credential {
+  public id: string
+  public pk: bigint
+
+  constructor(
+    public rp: string,
+    public user: Uint8Array,
+  ) {
+    this.pk = p256.utils.normPrivateKeyToScalar(p256.utils.randomPrivateKey())
+    this.id = ethers.dataSlice(ethers.keccak256(ethers.dataSlice(p256.getPublicKey(this.pk, false), 1)), 12)
+  }
+
+  public cosePublicKey(): string {
+    const pubk = p256.getPublicKey(this.pk, false)
+    const x = pubk.slice(1, 33)
+    const y = pubk.slice(33, 65)
+
+    // <https://webauthn.guide/#registration>
+    const key = new Map()
+    // <https://datatracker.ietf.org/doc/html/rfc8152#section-7>
+    key.set(1, 2) // kty = EC2
+    key.set(3, -7) // alg = ES256 (Elliptic curve signature with SHA-256)
+    // <https://datatracker.ietf.org/doc/html/rfc8152#section-13.1.1>
+    key.set(-1, 1) // crv = P-256
+    key.set(-2, x)
+    key.set(-3, y)
+
+    return ethers.hexlify(new Uint8Array(CBOR.encode(key).buffer))
+  }
+}
+
+export class WebAuthnCredentials {
+  #credentials: Credential[] = []
+
+  /**
+   * This is a shim for `navigator.credentials.create` method.
+   * See <https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-create>.
+   *
+   * @param options The public key credential creation options.
+   * @returns A public key credential with an attestation response.
+   */
+  public create({ publicKey }: CredentialCreationOptions): PublicKeyCredential<AuthenticatorAttestationResponse> {
+    const credential = new Credential(publicKey.rp.id, publicKey.user.id)
+    this.#credentials.push(credential)
+
+    // <https://w3c.github.io/webauthn/#dictionary-client-data>
+    const clientData = {
+      type: 'webauthn.create',
+      challenge: ethers.encodeBase64(publicKey.challenge).replace(/=*$/, ''),
+      origin: `https://${publicKey.rp.id}`,
+    }
+
+    // <https://w3c.github.io/webauthn/#sctn-attestation>
+    const attestationObject = {
+      authData: ethers.getBytes(
+        ethers.solidityPacked(
+          ['bytes32', 'uint8', 'uint32', 'bytes16', 'uint16', 'bytes', 'bytes'],
+          [
+            ethers.sha256(ethers.toUtf8Bytes(publicKey.rp.id)),
+            0x41, // flags = attested_data + user_present
+            0, // signCount
+            `0x${'42'.repeat(16)}`, // aaguid
+            credential.id.length,
+            credential.id,
+            credential.cosePublicKey(),
+          ],
+        ),
+      ),
+      fmt: 'none',
+      attStmt: {},
+    }
+
+    return {
+      id: ethers.encodeBase64(credential.id),
+      rawId: ethers.getBytes(credential.id),
+      response: {
+        clientDataJSON: ethers.toUtf8Bytes(JSON.stringify(clientData)).buffer,
+        attestationObject: CBOR.encode(attestationObject).buffer,
+      },
+      type: 'public-key',
+    }
+  }
+
+  /**
+   * This is a shim for `navigator.credentials.get` method.
+   * See <https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get>.
+   *
+   * @param options The public key credential request options.
+   * @returns A public key credential with an assertion response.
+   */
+  get({ publicKey }: CredentialRequestOptions): PublicKeyCredential<AuthenticatorAssertionResponse> {
+    const credential = this.#credentials.find((c) => c.rp === publicKey.rpId)
+    if (credential === undefined) {
+      throw new Error('credential not found')
+    }
+
+    // <https://w3c.github.io/webauthn/#dictionary-client-data>
+    const clientData = {
+      type: 'webauthn.get',
+      challenge: ethers.encodeBase64(publicKey.challenge).replace(/=*$/, ''),
+      origin: `https://${publicKey.rpId}`,
+    }
+
+    // <https://w3c.github.io/webauthn/#sctn-authenticator-data>
+    // Note that we use a constant 0 value for signCount to simplify things:
+    // > If the authenticator does not implement a signature counter, let the signature counter
+    // > value remain constant at zero.
+    const authenticatorData = ethers.solidityPacked(
+      ['bytes32', 'uint8', 'uint32'],
+      [
+        ethers.sha256(ethers.toUtf8Bytes(publicKey.rpId)),
+        0x01, // flags = user_present
+        0, // signCount
+      ],
+    )
+
+    // <https://w3c.github.io/webauthn/#sctn-op-get-assertion>
+    // <https://w3c.github.io/webauthn/#fig-signature>
+    const signature = p256.sign(
+      ethers.concat([authenticatorData, ethers.sha256(ethers.toUtf8Bytes(JSON.stringify(clientData)))]),
+      credential.pk,
+      {
+        lowS: false,
+        prehash: true,
+      },
+    )
+
+    return {
+      id: ethers.encodeBase64(credential.id),
+      rawId: ethers.getBytes(credential.id),
+      response: {
+        clientDataJSON: ethers.toUtf8Bytes(JSON.stringify(clientData)).buffer,
+        authenticatorData: ethers.getBytes(authenticatorData).buffer,
+        signature: signature.toDERRawBytes(false).buffer,
+        userHandle: credential.user,
+      },
+      type: 'public-key',
+    }
+  }
+}

--- a/4337/test/utils/webauthn.ts
+++ b/4337/test/utils/webauthn.ts
@@ -24,14 +24,11 @@ export interface PublicKeyCredentialCreationOptions {
   rp: { id: string; name: string }
   user: { id: Uint8Array; displayName: string; name: string }
   challenge: Uint8Array
-  pubKeyCredParams: [{ type: 'public-key'; alg: -7 }]
-  timeout?: undefined
-  excludeCredentials?: undefined
-  authenticatorSelection?: undefined
-  hints?: undefined
+  pubKeyCredParams: {
+    type: 'public-key'
+    alg: number
+  }[]
   attestation?: 'none'
-  attestationFormats?: undefined
-  extensions?: undefined
 }
 
 export interface CredentialRequestOptions {
@@ -44,18 +41,12 @@ export interface CredentialRequestOptions {
  */
 export interface PublicKeyCredentialRequestOptions {
   challenge: Uint8Array
-  timeout?: undefined
   rpId: string
   allowCredentials: {
     type: 'public-key'
     id: Uint8Array
-    transports?: undefined
   }[]
-  userVerification?: undefined
-  hints?: undefined
   attestation?: 'none'
-  attestationFormats?: undefined
-  extensions?: undefined
 }
 
 /**
@@ -86,7 +77,6 @@ export interface AuthenticatorAssertionResponse {
   authenticatorData: ArrayBuffer
   signature: ArrayBuffer
   userHandle: ArrayBuffer
-  attestationObject?: undefined
 }
 
 class Credential {
@@ -131,6 +121,10 @@ export class WebAuthnCredentials {
    * @returns A public key credential with an attestation response.
    */
   public create({ publicKey }: CredentialCreationOptions): PublicKeyCredential<AuthenticatorAttestationResponse> {
+    if (!publicKey.pubKeyCredParams.some(({ alg }) => alg === -7)) {
+      throw new Error('unsupported signature algorithm(s)')
+    }
+
     const credential = new Credential(publicKey.rp.id, publicKey.user.id)
     this.#credentials.push(credential)
 

--- a/4337/test/webauthn/WebAuthn.spec.ts
+++ b/4337/test/webauthn/WebAuthn.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests to verify WebAuthn shim implementation from `utils/webauthn.ts`
+ */
+
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from '@simplewebauthn/server'
+import { expect } from 'chai'
+import CBOR from 'cbor'
+import { ethers } from 'ethers'
+import { WebAuthnCredentials, base64UrlEncode } from '../utils/webauthn'
+
+describe('WebAuthn Shim', () => {
+  const navigator = {
+    credentials: new WebAuthnCredentials(),
+  }
+
+  const origin = 'https://safe.global'
+  const rp = {
+    name: 'Safe',
+    id: 'safe.global',
+  }
+
+  const user = {
+    id: ethers.getBytes(ethers.id('chucknorris')),
+    name: 'chucknorris',
+    displayName: 'Chuck Norris',
+  }
+
+  describe('navigator.credentials.create()', () => {
+    it('Safe with 4337 Module Deployment', async () => {
+      const options = await generateRegistrationOptions({
+        rpName: rp.name,
+        rpID: rp.id,
+        userID: base64UrlEncode(user.id),
+        userName: user.name,
+        userDisplayName: user.displayName,
+        attestationType: 'none',
+      })
+
+      const credential = navigator.credentials.create({
+        publicKey: {
+          rp: {
+            id: options.rp.id ?? '',
+            name: options.rp.name,
+          },
+          user: {
+            id: ethers.getBytes(ethers.decodeBase64(options.user.id)),
+            displayName: options.user.displayName,
+            name: options.user.name,
+          },
+          challenge: ethers.getBytes(ethers.decodeBase64(options.challenge)),
+          pubKeyCredParams: options.pubKeyCredParams,
+        },
+      })
+
+      const { verified } = await verifyRegistrationResponse({
+        response: {
+          id: credential.id,
+          rawId: base64UrlEncode(credential.rawId),
+          response: {
+            clientDataJSON: base64UrlEncode(credential.response.clientDataJSON),
+            attestationObject: base64UrlEncode(credential.response.attestationObject),
+          },
+          clientExtensionResults: {},
+          type: 'public-key',
+        },
+        expectedChallenge: options.challenge,
+        expectedOrigin: origin,
+        expectedRPID: rp.id,
+        requireUserVerification: false,
+      })
+
+      expect(verified).to.be.true
+    })
+  })
+
+  describe('navigator.credentials.get()', () => {
+    it('Safe with 4337 Module Deployment', async () => {
+      const credential = navigator.credentials.create({
+        publicKey: {
+          rp,
+          user,
+          challenge: ethers.toUtf8Bytes('challenge accepted!'),
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+        },
+      })
+
+      const attestationObject = CBOR.decode(credential.response.attestationObject)
+      const authDataView = new DataView(attestationObject.authData.buffer)
+      const credentialIdLength = authDataView.getUint16(53)
+      const credentialPublicKey = attestationObject.authData.slice(55 + credentialIdLength)
+
+      const options = await generateAuthenticationOptions({
+        rpID: rp.id,
+      })
+
+      const assertion = navigator.credentials.get({
+        publicKey: {
+          challenge: ethers.getBytes(ethers.decodeBase64(options.challenge)),
+          rpId: rp.id,
+          allowCredentials: [{ type: 'public-key', id: new Uint8Array(credential.rawId) }],
+        },
+      })
+
+      const { verified } = await verifyAuthenticationResponse({
+        response: {
+          id: assertion.id,
+          rawId: base64UrlEncode(assertion.rawId),
+          response: {
+            clientDataJSON: base64UrlEncode(assertion.response.clientDataJSON),
+            authenticatorData: base64UrlEncode(assertion.response.authenticatorData),
+            signature: base64UrlEncode(assertion.response.signature),
+          },
+          type: 'public-key',
+          clientExtensionResults: {},
+        },
+        expectedChallenge: options.challenge,
+        expectedOrigin: origin,
+        expectedRPID: rp.id,
+        authenticator: {
+          credentialPublicKey,
+          credentialID: new Uint8Array(credential.rawId),
+          counter: 0,
+        },
+        requireUserVerification: false,
+      })
+
+      expect(verified).to.be.true
+    })
+  })
+})

--- a/4337/test/webauthn/WebAuthn.spec.ts
+++ b/4337/test/webauthn/WebAuthn.spec.ts
@@ -31,7 +31,7 @@ describe('WebAuthn Shim', () => {
   }
 
   describe('navigator.credentials.create()', () => {
-    it('Safe with 4337 Module Deployment', async () => {
+    it('creates and verifies a new credential', async () => {
       const options = await generateRegistrationOptions({
         rpName: rp.name,
         rpID: rp.id,
@@ -79,7 +79,7 @@ describe('WebAuthn Shim', () => {
   })
 
   describe('navigator.credentials.get()', () => {
-    it('Safe with 4337 Module Deployment', async () => {
+    it('authorises and verifies an existing credential', async () => {
       const credential = navigator.credentials.create({
         publicKey: {
           rp,


### PR DESCRIPTION
This PR adds a `tests/utils/webauthn.ts` module that implements a shim for the Browser WebAuthn API (sometimes conflated with Passkeys).

I verified the implementation by testing both credential creation and assertion (i.e. signing) using a reference WebAuthn/Passkey server implementation (specifically `SimpleWebAuthn` which was suggested on the [Passkeys.dev website](https://passkeys.dev/docs/tools-libraries/libraries/#typescript)).

OMG debugging signature issues is annoying :sob: :sob: :sob: 

