### PR TITLE
[#169] Change branch name to main in certora.yml

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -3,12 +3,12 @@ name: certora
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - modules/4337/**
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - modules/4337/**
 


### PR DESCRIPTION
Fixes #169 

Changes in PR:

- Update `certora.yml` file to refer `main` instead of `master`