### PR TITLE
Add an updated EIP-1271 function to the WebAuthn signer

### DIFF
--- a/modules/4337/contracts/experimental/SafeSignerLaunchpad.sol
+++ b/modules/4337/contracts/experimental/SafeSignerLaunchpad.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.0 <0.9.0;
 import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";
 import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 import {_packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
-import {ISignatureValidator} from "@safe-global/safe-contracts/contracts/interfaces/ISignatureValidator.sol";
 import {SafeStorage} from "@safe-global/safe-contracts/contracts/libraries/SafeStorage.sol";
+import {SignatureValidatorConstants} from "./SignatureValidatorConstants.sol";
 
 interface IUniqueSignerFactory {
     /**
@@ -31,7 +31,7 @@ interface IUniqueSignerFactory {
      * @param data The data whose signature should be verified.
      * @param signature The signature bytes.
      * @param signerData The signer data to verify signature for.
-     * @return magicValue Returns `ISignatureValidator.isValidSignature.selector` when the signature is valid. Reverting or returning any other value implies an invalid signature.
+     * @return magicValue Returns a legacy EIP-1271 magic value (`keccak256(isValidSignature(bytes,bytes)`) when the signature is valid. Reverting or returning any other value implies an invalid signature.
      */
     function isValidSignatureForSigner(
         bytes calldata data,
@@ -44,7 +44,7 @@ interface IUniqueSignerFactory {
  * @title SafeOpLaunchpad - A contract for Safe initialization with custom unique signers that would violate ERC-4337 factory rules.
  * @dev The is intended to be set as a Safe proxy's implementation for ERC-4337 user operation that deploys the account.
  */
-contract SafeSignerLaunchpad is IAccount, SafeStorage {
+contract SafeSignerLaunchpad is IAccount, SafeStorage, SignatureValidatorConstants {
     bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
 
     // keccak256("SafeSignerLaunchpad.initHash") - 1
@@ -171,7 +171,7 @@ contract SafeSignerLaunchpad is IAccount, SafeStorage {
 
         bytes memory operationData = _getOperationData(userOpHash, validAfter, validUntil);
         bytes4 magicValue = IUniqueSignerFactory(signerFactory).isValidSignatureForSigner(operationData, signature, signerData);
-        validationData = _packValidationData(magicValue != ISignatureValidator.isValidSignature.selector, validUntil, validAfter);
+        validationData = _packValidationData(magicValue != LEGACY_EIP1271_MAGIC_VALUE, validUntil, validAfter);
 
         if (missingAccountFunds > 0) {
             // solhint-disable-next-line no-inline-assembly

--- a/modules/4337/contracts/experimental/SignatureValidatorConstants.sol
+++ b/modules/4337/contracts/experimental/SignatureValidatorConstants.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable one-contract-per-file */
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @title SignatureValidatorConstants
+ * @dev This contract defines the constants used for EIP-1271 signature validation.
+ */
+contract SignatureValidatorConstants {
+    // bytes4(keccak256("isValidSignature(bytes32,bytes)")
+    bytes4 internal constant EIP1271_MAGIC_VALUE = 0x1626ba7e;
+
+    // bytes4(keccak256("isValidSignature(bytes,bytes)")
+    bytes4 internal constant LEGACY_EIP1271_MAGIC_VALUE = 0x20c13b0b;
+}


### PR DESCRIPTION
This PR:
- Adds an updated EIP-1271 validation method to the WebAuthnSigner contract for futureproofing
- I created an abstract contract with both magic values, similar to how it's done in the Safe Account contract. We cannot reuse the Safe's contract because it only includes one value (either the legacy or the new one)
- I had to adjust the return values of signature-validating functions slightly. For the generic `checkSignatures` function, I changed it to a boolean, similar to how it's done in the underlying FCL's validation function
