### PR TITLE
Feature: Upgrade `certora-cli` version to v6

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -35,7 +35,7 @@ jobs:
         with: { java-version: '17', java-package: jre, distribution: semeru }
 
       - name: Install certora cli
-        run: pip install -Iv certora-cli==5.0.5
+        run: pip install -Iv certora-cli==6.1.3
 
       - name: Install solc
         run: |

--- a/modules/4337/certora/specs/Safe4337Module.spec
+++ b/modules/4337/certora/specs/Safe4337Module.spec
@@ -26,9 +26,9 @@ methods {
         Safe4337Module.UserOperation userOp
     ) external returns(bytes32) envfree => PER_CALLEE_CONSTANT;
 }
-ghost ERC2771MessageSender() returns address;
+persistent ghost ERC2771MessageSender() returns address;
 
-ghost bool checkSignaturesCalled;
+persistent ghost bool checkSignaturesCalled;
 
 function checkSignaturesFunctionCalled() returns bool {
     checkSignaturesCalled = true;

--- a/modules/4337/certora/specs/TransactionExecutionMethods.spec
+++ b/modules/4337/certora/specs/TransactionExecutionMethods.spec
@@ -13,7 +13,7 @@ methods {
     function executeUserOpWithErrorString(address, uint256, bytes, uint8) external;
 }
 
-ghost bool execTransactionFromModuleCalled {
+persistent ghost bool execTransactionFromModuleCalled {
     init_state axiom false;
 }
 


### PR DESCRIPTION
This PR:
- Upgrades certora cli spec file with V6 changes, mainly the change around how ghost variables are handled - now they may be HAVOC'ed between unresolved calls and we need to add the `persistent` keyword to persist them