### PR TITLE
Fix EntryPoint Natspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ env/
 .history
 coverage*
 .certora_internal
+.vscode

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -69,7 +69,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
     }
 
     /**
-     * @notice The EIP-712 type-hash for the domain separator used for verifying Safe operation signatures.
+     * @notice The EntryPoint Address supported by this Module.
      */
     address public immutable SUPPORTED_ENTRYPOINT;
 

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -69,7 +69,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
     }
 
     /**
-     * @notice The EntryPoint Address supported by this Module.
+     * @notice The address of the EntryPoint contract supported by this module.
      */
     address public immutable SUPPORTED_ENTRYPOINT;
 


### PR DESCRIPTION
Changes the NatSpec of `SUPPORTED_ENTRYPOINT` with the correct description.

Closes #214

Nit: Also added `.vscode` to `.gitignore`.