### PR TITLE
New Signature Encoding for Webauthn Signer

### DIFF
--- a/modules/4337/contracts/experimental/WebAuthn.sol
+++ b/modules/4337/contracts/experimental/WebAuthn.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import {FCL_ecdsa_utils} from "../vendor/FCL/FCL_ecdsa_utils.sol";
+import {Base64Url} from "../vendor/FCL/utils/Base64Url.sol";
+
+library WebAuthn {
+    function signingMessage(
+        bytes calldata authenticatorData,
+        bytes32 challenge,
+        bytes calldata clientDataFields
+    ) internal pure returns (bytes32 message) {
+        string memory encodedChallenge = Base64Url.encode(abi.encodePacked(challenge));
+        /* solhint-disable quotes */
+        bytes memory clientDataJson = abi.encodePacked(
+            '{"type":"webauthn.get","challenge":"',
+            encodedChallenge,
+            '",',
+            clientDataFields,
+            "}"
+        );
+        /* solhint-enable quotes */
+        message = sha256(abi.encodePacked(authenticatorData, sha256(clientDataJson)));
+    }
+
+    function checkSignature(
+        bytes calldata authenticatorData,
+        bytes1 authenticatorFlags,
+        bytes32 challenge,
+        bytes calldata clientDataFields,
+        uint256[2] calldata rs,
+        uint256 qx,
+        uint256 qy
+    ) internal view returns (bool result) {
+        // check authenticator flags, e.g. for User Presence (0x01) and/or User Verification (0x04)
+        if ((authenticatorData[32] & authenticatorFlags) != authenticatorFlags) {
+            return false;
+        }
+
+        bytes32 message = signingMessage(authenticatorData, challenge, clientDataFields);
+        result = FCL_ecdsa_utils.ecdsa_verify(message, rs, qx, qy);
+    }
+}

--- a/modules/4337/contracts/experimental/WebAuthnSigner.sol
+++ b/modules/4337/contracts/experimental/WebAuthnSigner.sol
@@ -2,14 +2,13 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity >=0.8.0;
 
-import {FCL_WebAuthn} from "../vendor/FCL/FCL_Webauthn.sol";
-import {SignatureValidatorConstants} from "./SignatureValidatorConstants.sol";
 import {IUniqueSignerFactory} from "./SafeSignerLaunchpad.sol";
+import {SignatureValidatorConstants} from "./SignatureValidatorConstants.sol";
+import {WebAuthn} from "./WebAuthn.sol";
 
 struct SignatureData {
     bytes authenticatorData;
-    bytes clientData;
-    uint256 challengeOffset;
+    bytes clientDataFields;
     uint256[2] rs;
 }
 
@@ -21,12 +20,11 @@ function checkSignature(bytes memory data, bytes calldata signature, uint256 x, 
     }
 
     return
-        FCL_WebAuthn.checkSignature(
+        WebAuthn.checkSignature(
             signaturePointer.authenticatorData,
             0x01, // require user presence
-            signaturePointer.clientData,
             keccak256(data),
-            signaturePointer.challengeOffset,
+            signaturePointer.clientDataFields,
             signaturePointer.rs,
             x,
             y

--- a/modules/4337/test/e2e/WebAuthnSigner.spec.ts
+++ b/modules/4337/test/e2e/WebAuthnSigner.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { deployments, ethers, network } from 'hardhat'
 import { bundlerRpc, prepareAccounts, waitForUserOp } from '../utils/e2e'
 import { chainId } from '../utils/encoding'
-import { WebAuthnCredentials, extractChallengeOffset, extractPublicKey, extractSignature } from '../utils/webauthn'
+import { WebAuthnCredentials, extractClientDataFields, extractPublicKey, extractSignature } from '../utils/webauthn'
 
 describe('E2E - WebAuthn Signers', () => {
   before(function () {
@@ -168,11 +168,10 @@ describe('E2E - WebAuthn Signers', () => {
         safeInitOp.validAfter,
         safeInitOp.validUntil,
         ethers.AbiCoder.defaultAbiCoder().encode(
-          ['bytes', 'bytes', 'uint256', 'uint256[2]'],
+          ['bytes', 'bytes', 'uint256[2]'],
           [
             new Uint8Array(assertion.response.authenticatorData),
-            new Uint8Array(assertion.response.clientDataJSON),
-            extractChallengeOffset(assertion.response, safeInitOpHash),
+            extractClientDataFields(assertion.response),
             extractSignature(assertion.response),
           ],
         ),

--- a/modules/4337/test/erc4337/ERC4337WebAuthn.spec.ts
+++ b/modules/4337/test/erc4337/ERC4337WebAuthn.spec.ts
@@ -4,7 +4,7 @@ import { deployReferenceEntryPoint } from '../utils/setup'
 import { buildContractSignatureBytes, logGas } from '../../src/utils/execution'
 import { buildSafeUserOpTransaction, buildUserOperationFromSafeUserOperation, calculateSafeOperationHash } from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
-import { WebAuthnCredentials, extractChallengeOffset, extractPublicKey, extractSignature } from '../utils/webauthn'
+import { WebAuthnCredentials, extractClientDataFields, extractPublicKey, extractSignature } from '../utils/webauthn'
 import { Safe4337 } from '../../src/utils/safe'
 
 describe('Safe4337Module - WebAuthn Owner', () => {
@@ -166,11 +166,10 @@ describe('Safe4337Module - WebAuthn Owner', () => {
           safeInitOp.validAfter,
           safeInitOp.validUntil,
           ethers.AbiCoder.defaultAbiCoder().encode(
-            ['bytes', 'bytes', 'uint256', 'uint256[2]'],
+            ['bytes', 'bytes', 'uint256[2]'],
             [
               new Uint8Array(assertion.response.authenticatorData),
-              new Uint8Array(assertion.response.clientDataJSON),
-              extractChallengeOffset(assertion.response, safeInitOpHash),
+              extractClientDataFields(assertion.response),
               extractSignature(assertion.response),
             ],
           ),
@@ -250,11 +249,10 @@ describe('Safe4337Module - WebAuthn Owner', () => {
         {
           signer: signer.target as string,
           data: ethers.AbiCoder.defaultAbiCoder().encode(
-            ['bytes', 'bytes', 'uint256', 'uint256[2]'],
+            ['bytes', 'bytes', 'uint256[2]'],
             [
               new Uint8Array(assertion.response.authenticatorData),
-              new Uint8Array(assertion.response.clientDataJSON),
-              extractChallengeOffset(assertion.response, safeOpHash),
+              extractClientDataFields(assertion.response),
               extractSignature(assertion.response),
             ],
           ),


### PR DESCRIPTION
Fixes #220 

This PR proposes a new signature encoding scheme for the Webauthn signer. This takes advantage of the [`clientDataJSON` serialization specification]() which requires a specific ordering and formatting (no additional whitespace) for the fields). Notably, this scheme:

* reduces the amount of calldata by 114 bytes per signature; this is non-trivial in the context of reducing calldata for rollups (where calldata is more expensive than computation).
* no longer requires a trusted `challengeOffset` (which has some security implications).

I plan to upstream these changes to FCL after doing a bit of investigation on potentially optimizing:
- base64 encoding of the challenge (since we use a fixed 32-byte challenge while the library allows for arbitrary `bytes`)
- byte concatenation logic to try and make it slightly more gas efficient