### PR TITLE
Fix reference to inexisting package `@safe-global/safe-eip4337`

### DIFF
--- a/examples/safe-4337-passkeys/package.json
+++ b/examples/safe-4337-passkeys/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@web3modal/ethers": "^3.5.7",
-    "@safe-global/safe-eip4337": "^0.2.0",
+    "@safe-global/safe-erc4337": "^0.2.0",
     "ethers": "^6.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/safe-4337-passkeys/src/logic/safe.ts
+++ b/examples/safe-4337-passkeys/src/logic/safe.ts
@@ -1,13 +1,13 @@
 import { ethers } from 'ethers'
-import { abi as SafeSignerLaunchpadAbi } from '@safe-global/safe-eip4337/build/artifacts/contracts/experimental/SafeSignerLaunchpad.sol/SafeSignerLaunchpad.json'
-import { abi as WebAuthnSignerFactoryAbi } from '@safe-global/safe-eip4337/build/artifacts/contracts/experimental/WebAuthnSigner.sol/WebAuthnSignerFactory.json'
-import { abi as AddModulesLibAbi } from '@safe-global/safe-eip4337/build/artifacts/contracts/AddModulesLib.sol/AddModulesLib.json'
+import { abi as SafeSignerLaunchpadAbi } from '@safe-global/safe-erc4337/build/artifacts/contracts/experimental/SafeSignerLaunchpad.sol/SafeSignerLaunchpad.json'
+import { abi as WebAuthnSignerFactoryAbi } from '@safe-global/safe-erc4337/build/artifacts/contracts/experimental/WebAuthnSigner.sol/WebAuthnSignerFactory.json'
+import { abi as AddModulesLibAbi } from '@safe-global/safe-erc4337/build/artifacts/contracts/AddModulesLib.sol/AddModulesLib.json'
 import {
   abi as WebAuthnSignerAbi,
   bytecode as WebAuthSignerBytecode,
-} from '@safe-global/safe-eip4337/build/artifacts/contracts/experimental/WebAuthnSigner.sol/WebAuthnSigner.json'
-import { abi as Safe4337ModuleAbi } from '@safe-global/safe-eip4337/build/artifacts/contracts/Safe4337Module.sol/Safe4337Module.json'
-import { abi as SafeProxyFactoryAbi } from '@safe-global/safe-eip4337/build/artifacts/@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol/SafeProxyFactory.json'
+} from '@safe-global/safe-erc4337/build/artifacts/contracts/experimental/WebAuthnSigner.sol/WebAuthnSigner.json'
+import { abi as Safe4337ModuleAbi } from '@safe-global/safe-erc4337/build/artifacts/contracts/Safe4337Module.sol/Safe4337Module.json'
+import { abi as SafeProxyFactoryAbi } from '@safe-global/safe-erc4337/build/artifacts/@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol/SafeProxyFactory.json'
 import type {
   SafeSignerLaunchpad,
   Safe4337Module,
@@ -15,7 +15,7 @@ import type {
   WebAuthnSigner,
   WebAuthnSignerFactory,
   AddModulesLib,
-} from '@safe-global/safe-eip4337/typechain-types/'
+} from '@safe-global/safe-erc4337/typechain-types/'
 
 import {
   SAFE_SIGNER_LAUNCHPAD_ADDRESS,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     "examples/safe-4337-passkeys": {
       "version": "0.0.0",
       "dependencies": {
-        "@safe-global/safe-eip4337": "^0.2.0",
+        "@safe-global/safe-erc4337": "^0.2.0",
         "@web3modal/ethers": "^3.5.7",
         "ethers": "^6.10.0",
         "react": "^18.2.0",
@@ -29403,7 +29403,7 @@
     "safe-4337-passkeys": {
       "version": "file:examples/safe-4337-passkeys",
       "requires": {
-        "@safe-global/safe-eip4337": "^0.2.0",
+        "@safe-global/safe-erc4337": "^0.2.0",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react-swc": "^3.5.0",


### PR DESCRIPTION
This PR:
- Fixes broken install step by replacing references to previously renamed `@safe-global/safe-eip4337` package