### PR TITLE
Revert EntryPoint Natspec Fix

### DIFF
--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -69,7 +69,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
     }
 
     /**
-     * @notice The address of the EntryPoint contract supported by this module.
+     * @notice The EIP-712 type-hash for the domain separator used for verifying Safe operation signatures.
      */
     address public immutable SUPPORTED_ENTRYPOINT;
 


### PR DESCRIPTION
This PR reverts the `SUPPORTED_ENTRYPOINT` NatSpec documentation fix from safe-global/safe-modules#216. This issue was reported as part of the OZ audit, and should be fixed as part of a separate process.

Just reverting here to make that process easier.