### PR TITLE
[L-01] Specific Solidity Version for Contracts

### DIFF
--- a/modules/4337/contracts/AddModulesLib.sol
+++ b/modules/4337/contracts/AddModulesLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.23;
 
 import {ISafe} from "./interfaces/Safe.sol";
 

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.23;
 
 import {HandlerContext} from "@safe-global/safe-contracts/contracts/handler/HandlerContext.sol";
 import {CompatibilityFallbackHandler} from "@safe-global/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol";


### PR DESCRIPTION
This PR addresses the issue L-01 from the audit report.

Specifically, it implements the suggestion to not use floating pragmas, but specific Solidity compiler versions for the contracts.