### PR TITLE
[L-02] Fix Misleading Comments in Contract Code

### DIFF
--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -69,7 +69,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
     }
 
     /**
-     * @notice The EIP-712 type-hash for the domain separator used for verifying Safe operation signatures.
+     * @notice The address of the EntryPoint contract supported by this module.
      */
     address public immutable SUPPORTED_ENTRYPOINT;
 
@@ -96,9 +96,9 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         uint256 missingAccountFunds
     ) external onlySupportedEntryPoint returns (uint256 validationData) {
         address payable safeAddress = payable(userOp.sender);
-        // The entry point address is appended to the calldata in `HandlerContext` contract
-        // Because of this, the relayer may manipulate the entry point address, therefore we have to verify that
-        // the sender is the Safe specified in the userOperation
+        // The entry point address is appended to the calldata by the Safe in the `FallbackManager` contract,
+        // following ERC-2771. Because of this, the relayer may manipulate the entry point address, therefore
+        // we have to verify that the sender is the Safe specified in the userOperation.
         require(safeAddress == msg.sender, "Invalid caller");
 
         // We check the execution function signature to make sure the entry point can't call any other function


### PR DESCRIPTION
This PR addresses issue `L-02` from the audit report.

In particular it fixes two comments that were found to be inaccurate:
1. `SUPPORTED_ENTRYPOINT` NatSpec documentation
2. Comment explaining which contract was responsible for appending the `msg.sender` as per [ERC-2771](https://eips.ethereum.org/EIPS/eip-2771).

Additionally, I went through other comments in `Safe4337Module.sol` for additional errors (but did not find any).