### PR TITLE
[L-03, N-01, N-02] Fixes to `SafeSetupModule` (formerly `AddModulesLib`)

### DIFF
--- a/modules/4337/.env.sample
+++ b/modules/4337/.env.sample
@@ -14,7 +14,7 @@ SCRIPT_BUNDLER_URL=""
 # Module to use in the user op test script
 SCRIPT_MODULE_ADDRESS=""
 # Library to add modules in the user op test script
-SCRIPT_ADD_MODULES_LIB_ADDRESS=""
+SCRIPT_SAFE_MODULE_SETUP_ADDRESS=""
 # Proxy factory to use in the user op test script
 SCRIPT_PROXY_FACTORY_ADDRESS=""
 # Singleton address to use in the user op test script

--- a/modules/4337/README.md
+++ b/modules/4337/README.md
@@ -62,7 +62,7 @@ Important to note that [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337#first-
 
 > The initCode field (if non-zero length) is parsed as a 20-byte address, followed by "calldata" to pass to this address.
 
-To deploy a Safe with 4337 directly enabled, we require a setup library that enables multiple modules (`AddModulesLib`). This is necessary because to enable a Module, the Safe has to do a call to itself. Before calling the setup method, we do not know the address of the Safe yet (as the address depends on the setup parameters) and using MultiSend will not result in the correct `msg.sender` for a selfcall.
+To deploy a Safe with 4337 directly enabled, we require a setup contract that enables multiple modules (`SafeModuleSetup`). This is necessary because to enable a Module, the Safe has to do a call to itself. Before calling the setup method, we do not know the address of the Safe yet (as the address depends on the setup parameters) and using MultiSend will not result in the correct `msg.sender` for a selfcall.
 
 The `initCode` for the Safe with a 4337 module enabled is composed in the following way:
 
@@ -76,7 +76,7 @@ bytes memory initializer = abi.encodeWithSignature(
     "setup(address[],uint256,address,bytes,address,address,uint256,address)",
     owners,
     threshold,
-    ADD_MODULES_LIB_ADDRESS,
+    SAFE_MODULE_SETUP_ADDRESS,
     abi.encodeWithSignature("enableModules(address[])", modules),
     SAFE_4337_MODULE_ADDRESS,
     // We do not want to use any refund logic; therefore, this is all set to 0
@@ -105,7 +105,7 @@ sequenceDiagram
     participant E as Entry Point
     participant F as Safe Proxy Factory
     participant P as Safe Proxy
-    participant L as AddModulesLib
+    participant L as SafeModuleSetup
     B->>+E: Submit User Operations with `initCode`
     E->>+F: Deploy Proxy with `deployData`
     F->>+P: Create Proxy

--- a/modules/4337/contracts/SafeModuleSetup.sol
+++ b/modules/4337/contracts/SafeModuleSetup.sol
@@ -19,9 +19,8 @@ contract SafeModuleSetup {
      * @param modules The modules to enable.
      */
     function enableModules(address[] calldata modules) external {
-        for (uint256 i = modules.length; i > 0; i--) {
-            // This call will only work properly if used via a delegatecall
-            ISafe(address(this)).enableModule(modules[i - 1]);
+        for (uint256 i = 0; i < modules.length; i++) {
+            ISafe(address(this)).enableModule(modules[i]);
         }
     }
 }

--- a/modules/4337/contracts/SafeModuleSetup.sol
+++ b/modules/4337/contracts/SafeModuleSetup.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {ISafe} from "./interfaces/Safe.sol";
 
-/// @title AddModulesLib
-contract AddModulesLib {
+/// @title SafeModuleSetup
+contract SafeModuleSetup {
     function enableModules(address[] calldata modules) external {
         for (uint256 i = modules.length; i > 0; i--) {
             // This call will only work properly if used via a delegatecall

--- a/modules/4337/contracts/SafeModuleSetup.sol
+++ b/modules/4337/contracts/SafeModuleSetup.sol
@@ -3,8 +3,21 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {ISafe} from "./interfaces/Safe.sol";
 
-/// @title SafeModuleSetup
+/**
+ * @title SafeModuleSetup - A utility contract for setting up a Safe with modules.
+ * @dev The Safe `setup` function accepts `to` and `data` parameters for a delegate call during initialization. This
+ *      contract can be specified as the `to` with `data` ABI encoding the `enableModules` call so that a Safe is
+ *      created with the specified modules. In particular, this allows a ERC-4337 compatible Safe to be created as part
+ *      of a ERC-4337 user operation with the `Safe4337Module` enabled right away.
+ * @custom:security-contact bounty@safe.global
+ */
 contract SafeModuleSetup {
+    /**
+     * @notice Enable the specified Safe modules.
+     * @dev This call will only work if used from a Safe via delegatecall. It is intended to be used as part of the
+     *      Safe `setup`, allowing Safes to be created with an initial set of enabled modules.
+     * @param modules The modules to enable.
+     */
     function enableModules(address[] calldata modules) external {
         for (uint256 i = modules.length; i > 0; i--) {
             // This call will only work properly if used via a delegatecall

--- a/modules/4337/contracts/test/InitCode.sol
+++ b/modules/4337/contracts/test/InitCode.sol
@@ -3,19 +3,19 @@ pragma solidity >=0.8.0;
 
 contract InitCode {
     struct Config {
-        address addModulesLib;
+        address safeModuleSetup;
         address erc4337module;
         address safeSingleton;
         address proxyFactory;
     }
 
-    address public immutable ADD_MODULES_LIB_ADDRESS;
+    address public immutable SAFE_MODULE_SETUP_ADDRESS;
     address public immutable SAFE_4337_MODULE_ADDRESS;
     address public immutable SAFE_SINGLETON_ADDRESS;
     address public immutable SAFE_PROXY_FACTORY_ADDRESS;
 
     constructor(Config memory config) {
-        ADD_MODULES_LIB_ADDRESS = config.addModulesLib;
+        SAFE_MODULE_SETUP_ADDRESS = config.safeModuleSetup;
         SAFE_4337_MODULE_ADDRESS = config.erc4337module;
         SAFE_SINGLETON_ADDRESS = config.safeSingleton;
         SAFE_PROXY_FACTORY_ADDRESS = config.proxyFactory;
@@ -35,7 +35,7 @@ contract InitCode {
             "setup(address[],uint256,address,bytes,address,address,uint256,address)",
             owners,
             threshold,
-            ADD_MODULES_LIB_ADDRESS,
+            SAFE_MODULE_SETUP_ADDRESS,
             abi.encodeWithSignature("enableModules(address[])", modules),
             SAFE_4337_MODULE_ADDRESS,
             // We do not want to use any refund logic; therefore, this is all set to 0

--- a/modules/4337/scripts/runOp.ts
+++ b/modules/4337/scripts/runOp.ts
@@ -11,7 +11,7 @@ const MNEMONIC = process.env.SCRIPT_MNEMONIC
 const BUNDLER_URL = process.env.SCRIPT_BUNDLER_URL
 const SAFE_SINGLETON_ADDRESS = process.env.SCRIPT_SAFE_SINGLETON_ADDRESS!!
 const PROXY_FACTORY_ADDRESS = process.env.SCRIPT_PROXY_FACTORY_ADDRESS!!
-const ADD_MODULES_LIB_ADDRESS = process.env.SCRIPT_ADD_MODULES_LIB_ADDRESS!!
+const SAFE_MODULE_SETUP_ADDRESS = process.env.SCRIPT_SAFE_MODULE_SETUP_ADDRESS!!
 const MODULE_ADDRESS = process.env.SCRIPT_MODULE_ADDRESS!!
 const ERC20_TOKEN_ADDRESS = process.env.SCRIPT_ERC20_TOKEN_ADDRESS!!
 
@@ -61,7 +61,7 @@ const runOp = async () => {
     erc4337module: MODULE_ADDRESS,
     proxyFactory: PROXY_FACTORY_ADDRESS,
     proxyCreationCode,
-    addModulesLib: ADD_MODULES_LIB_ADDRESS,
+    safeModuleSetup: SAFE_MODULE_SETUP_ADDRESS,
     chainId: Number(await chainId()),
   }
   const safe = await Safe4337.withSigner(user1.address, globalConfig)

--- a/modules/4337/src/deploy/libraries.ts
+++ b/modules/4337/src/deploy/libraries.ts
@@ -4,7 +4,7 @@ const deploy: DeployFunction = async ({ deployments, getNamedAccounts }) => {
   const { deployer } = await getNamedAccounts()
   const { deploy } = deployments
 
-  await deploy('AddModulesLib', {
+  await deploy('SafeModuleSetup', {
     from: deployer,
     args: [],
     log: true,

--- a/modules/4337/src/utils/safe.ts
+++ b/modules/4337/src/utils/safe.ts
@@ -41,7 +41,7 @@ export interface GlobalConfig {
   erc4337module: string
   proxyFactory: string
   proxyCreationCode: string
-  addModulesLib: string
+  safeModuleSetup: string
   chainId: number
 }
 
@@ -62,7 +62,7 @@ const buildInitParamsForConfig = (safeConfig: SafeConfig, globalConfig: GlobalCo
   const setupData = INTERFACES.encodeFunctionData('setup', [
     safeConfig.signers,
     safeConfig.threshold,
-    globalConfig.addModulesLib,
+    globalConfig.safeModuleSetup,
     initData,
     globalConfig.erc4337module,
     ethers.ZeroAddress,

--- a/modules/4337/test/docs/InitCode.spec.ts
+++ b/modules/4337/test/docs/InitCode.spec.ts
@@ -10,7 +10,7 @@ describe('InitCode', () => {
       entryPoint: addr(0x02),
       erc4337module: addr(0x03),
       proxyFactory: addr(0x04),
-      addModulesLib: addr(0x05),
+      safeModuleSetup: addr(0x05),
       proxyCreationCode: '0x',
       chainId: 42,
     }

--- a/modules/4337/test/e2e/LocalBundler.spec.ts
+++ b/modules/4337/test/e2e/LocalBundler.spec.ts
@@ -14,7 +14,7 @@ describe('E2E - Local Bundler', () => {
   })
 
   const setupTests = async () => {
-    const { AddModulesLib, EntryPoint, HariWillibaldToken, Safe4337Module, SafeL2, SafeProxyFactory } = await deployments.run()
+    const { SafeModuleSetup, EntryPoint, HariWillibaldToken, Safe4337Module, SafeL2, SafeProxyFactory } = await deployments.run()
     const [user] = await prepareAccounts()
     const bundler = bundlerRpc()
 
@@ -29,7 +29,7 @@ describe('E2E - Local Bundler', () => {
       entryPoint: EntryPoint.address,
       erc4337module: Safe4337Module.address,
       proxyFactory: SafeProxyFactory.address,
-      addModulesLib: AddModulesLib.address,
+      safeModuleSetup: SafeModuleSetup.address,
       proxyCreationCode,
       chainId: Number(await chainId()),
     })

--- a/modules/4337/test/e2e/SingletonSigners.spec.ts
+++ b/modules/4337/test/e2e/SingletonSigners.spec.ts
@@ -12,14 +12,14 @@ describe('E2E - Singleton Signers', () => {
   })
 
   const setupTests = async () => {
-    const { AddModulesLib, EntryPoint, MultiSend, Safe4337Module, SafeL2, SafeProxyFactory } = await deployments.run()
+    const { SafeModuleSetup, EntryPoint, MultiSend, Safe4337Module, SafeL2, SafeProxyFactory } = await deployments.run()
     const [user] = await prepareAccounts()
     const bundler = bundlerRpc()
 
     const entryPoint = new ethers.Contract(EntryPoint.address, EntryPoint.abi, ethers.provider)
     const validator = await ethers.getContractAt('Safe4337Module', Safe4337Module.address)
     const proxyFactory = await ethers.getContractAt('SafeProxyFactory', SafeProxyFactory.address)
-    const addModulesLib = await ethers.getContractAt('AddModulesLib', AddModulesLib.address)
+    const safeModuleSEtup = await ethers.getContractAt('SafeModuleSetup', SafeModuleSetup.address)
     const multiSend = await ethers.getContractAt('MultiSend', MultiSend.address)
     const safeSingleton = await ethers.getContractAt('SafeL2', SafeL2.address)
 
@@ -48,7 +48,7 @@ describe('E2E - Singleton Signers', () => {
       bundler,
       validator,
       entryPoint,
-      addModulesLib,
+      safeModuleSEtup,
       multiSend,
       proxyFactory,
       safeSingleton,
@@ -58,15 +58,15 @@ describe('E2E - Singleton Signers', () => {
   }
 
   it('should deploy a new Safe with alternate signing scheme accessing associated storage', async () => {
-    const { user, bundler, validator, entryPoint, addModulesLib, multiSend, proxyFactory, safeSingleton, stakedFactory, customSigners } =
+    const { user, bundler, validator, entryPoint, safeModuleSEtup, multiSend, proxyFactory, safeSingleton, stakedFactory, customSigners } =
       await setupTests()
 
     const initData = multiSend.interface.encodeFunctionData('multiSend', [
       encodeMultiSendTransactions([
         {
           op: 1,
-          to: addModulesLib.target,
-          data: addModulesLib.interface.encodeFunctionData('enableModules', [[validator.target]]),
+          to: safeModuleSEtup.target,
+          data: safeModuleSEtup.interface.encodeFunctionData('enableModules', [[validator.target]]),
         },
         ...customSigners.map(({ signer, key }) => ({
           op: 0 as const,

--- a/modules/4337/test/e2e/UniqueSigner.spec.ts
+++ b/modules/4337/test/e2e/UniqueSigner.spec.ts
@@ -11,14 +11,15 @@ describe('E2E - Unique Signers', () => {
   })
 
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { EntryPoint, Safe4337Module, SafeSignerLaunchpad, SafeProxyFactory, AddModulesLib, SafeL2, MultiSend } = await deployments.run()
+    const { EntryPoint, Safe4337Module, SafeSignerLaunchpad, SafeProxyFactory, SafeModuleSetup, SafeL2, MultiSend } =
+      await deployments.run()
     const [user] = await prepareAccounts()
     const bundler = bundlerRpc()
 
     const entryPoint = await ethers.getContractAt('IEntryPoint', EntryPoint.address)
     const module = await ethers.getContractAt('Safe4337Module', Safe4337Module.address)
     const proxyFactory = await ethers.getContractAt('SafeProxyFactory', SafeProxyFactory.address)
-    const addModulesLib = await ethers.getContractAt('AddModulesLib', AddModulesLib.address)
+    const safeModuleSetup = await ethers.getContractAt('SafeModuleSetup', SafeModuleSetup.address)
     const signerLaunchpad = await ethers.getContractAt('SafeSignerLaunchpad', SafeSignerLaunchpad.address)
     const singleton = await ethers.getContractAt('SafeL2', SafeL2.address)
     const multiSend = await ethers.getContractAt('MultiSend', MultiSend.address)
@@ -30,7 +31,7 @@ describe('E2E - Unique Signers', () => {
       user,
       bundler,
       proxyFactory,
-      addModulesLib,
+      safeModuleSetup,
       module,
       entryPoint,
       signerLaunchpad,
@@ -41,7 +42,8 @@ describe('E2E - Unique Signers', () => {
   })
 
   it('should execute a user op and deploy a unique signer', async () => {
-    const { user, bundler, proxyFactory, addModulesLib, module, entryPoint, signerLaunchpad, singleton, signerFactory } = await setupTests()
+    const { user, bundler, proxyFactory, safeModuleSetup, module, entryPoint, signerLaunchpad, singleton, signerFactory } =
+      await setupTests()
 
     const key = BigInt(ethers.id('1'))
     const signerData = ethers.toBeHex(key, 32)
@@ -51,8 +53,8 @@ describe('E2E - Unique Signers', () => {
       singleton: singleton.target,
       signerFactory: signerFactory.target,
       signerData,
-      setupTo: addModulesLib.target,
-      setupData: addModulesLib.interface.encodeFunctionData('enableModules', [[module.target]]),
+      setupTo: safeModuleSetup.target,
+      setupData: safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]]),
       fallbackHandler: module.target,
     }
     const safeInitHash = ethers.TypedDataEncoder.hash(

--- a/modules/4337/test/e2e/WebAuthnSigner.spec.ts
+++ b/modules/4337/test/e2e/WebAuthnSigner.spec.ts
@@ -12,14 +12,14 @@ describe('E2E - WebAuthn Signers', () => {
   })
 
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { EntryPoint, Safe4337Module, SafeSignerLaunchpad, SafeProxyFactory, AddModulesLib, SafeL2 } = await deployments.run()
+    const { EntryPoint, Safe4337Module, SafeSignerLaunchpad, SafeProxyFactory, SafeModuleSetup, SafeL2 } = await deployments.run()
     const [user] = await prepareAccounts()
     const bundler = bundlerRpc()
 
     const entryPoint = await ethers.getContractAt('IEntryPoint', EntryPoint.address)
     const module = await ethers.getContractAt('Safe4337Module', Safe4337Module.address)
     const proxyFactory = await ethers.getContractAt('SafeProxyFactory', SafeProxyFactory.address)
-    const addModulesLib = await ethers.getContractAt('AddModulesLib', AddModulesLib.address)
+    const safeModuleSetup = await ethers.getContractAt('SafeModuleSetup', SafeModuleSetup.address)
     const signerLaunchpad = await ethers.getContractAt('SafeSignerLaunchpad', SafeSignerLaunchpad.address)
     const singleton = await ethers.getContractAt('SafeL2', SafeL2.address)
 
@@ -34,7 +34,7 @@ describe('E2E - WebAuthn Signers', () => {
       user,
       bundler,
       proxyFactory,
-      addModulesLib,
+      safeModuleSetup,
       module,
       entryPoint,
       signerLaunchpad,
@@ -45,7 +45,7 @@ describe('E2E - WebAuthn Signers', () => {
   })
 
   it('should execute a user op and deploy a WebAuthn signer', async () => {
-    const { user, bundler, proxyFactory, addModulesLib, module, entryPoint, signerLaunchpad, singleton, signerFactory, navigator } =
+    const { user, bundler, proxyFactory, safeModuleSetup, module, entryPoint, signerLaunchpad, singleton, signerFactory, navigator } =
       await setupTests()
 
     const credential = navigator.credentials.create({
@@ -71,8 +71,8 @@ describe('E2E - WebAuthn Signers', () => {
       singleton: singleton.target,
       signerFactory: signerFactory.target,
       signerData,
-      setupTo: addModulesLib.target,
-      setupData: addModulesLib.interface.encodeFunctionData('enableModules', [[module.target]]),
+      setupTo: safeModuleSetup.target,
+      setupData: safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]]),
       fallbackHandler: module.target,
     }
     const safeInitHash = ethers.TypedDataEncoder.hash(

--- a/modules/4337/test/erc4337/ERC4337ModuleNew.spec.ts
+++ b/modules/4337/test/erc4337/ERC4337ModuleNew.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
-import { getSafe4337Module, getEntryPoint, getFactory, getAddModulesLib, getSafeL2Singleton } from '../utils/setup'
+import { getSafe4337Module, getEntryPoint, getFactory, getSafeModuleSetup, getSafeL2Singleton } from '../utils/setup'
 import { buildSignatureBytes, logGas } from '../../src/utils/execution'
 import { buildUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp } from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
@@ -15,14 +15,14 @@ describe('Safe4337Module - Newly deployed safe', () => {
     const module = await getSafe4337Module()
     const proxyFactory = await getFactory()
     const proxyCreationCode = await proxyFactory.proxyCreationCode()
-    const addModulesLib = await getAddModulesLib()
+    const safeModuleSetup = await getSafeModuleSetup()
     const singleton = await getSafeL2Singleton()
     const safe = await Safe4337.withSigner(user1.address, {
       safeSingleton: await singleton.getAddress(),
       entryPoint: await entryPoint.getAddress(),
       erc4337module: await module.getAddress(),
       proxyFactory: await proxyFactory.getAddress(),
-      addModulesLib: await addModulesLib.getAddress(),
+      safeModuleSetup: await safeModuleSetup.getAddress(),
       proxyCreationCode,
       chainId: Number(await chainId()),
     })
@@ -31,7 +31,7 @@ describe('Safe4337Module - Newly deployed safe', () => {
       user1,
       safe: safe.connect(ethers.provider),
       proxyFactory,
-      addModulesLib,
+      safeModuleSetup,
       validator: module,
       entryPoint,
     }

--- a/modules/4337/test/erc4337/ERC4337WebAuthn.spec.ts
+++ b/modules/4337/test/erc4337/ERC4337WebAuthn.spec.ts
@@ -9,14 +9,14 @@ import { Safe4337 } from '../../src/utils/safe'
 
 describe('Safe4337Module - WebAuthn Owner', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { AddModulesLib, SafeL2, SafeProxyFactory } = await deployments.fixture()
+    const { SafeModuleSetup, SafeL2, SafeProxyFactory } = await deployments.fixture()
 
     const [deployer, relayer, user] = await ethers.getSigners()
     const entryPoint = await deployReferenceEntryPoint(deployer, relayer)
     const moduleFactory = await ethers.getContractFactory('Safe4337Module')
     const module = await moduleFactory.deploy(entryPoint.target)
     const proxyFactory = await ethers.getContractAt('SafeProxyFactory', SafeProxyFactory.address)
-    const addModulesLib = await ethers.getContractAt('AddModulesLib', AddModulesLib.address)
+    const safeModuleSetup = await ethers.getContractAt('SafeModuleSetup', SafeModuleSetup.address)
     const signerLaunchpadFactory = await ethers.getContractFactory('SafeSignerLaunchpad')
     const signerLaunchpad = await signerLaunchpadFactory.deploy(entryPoint.target)
     const singleton = await ethers.getContractAt('SafeL2', SafeL2.address)
@@ -31,7 +31,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
     return {
       user,
       proxyFactory,
-      addModulesLib,
+      safeModuleSetup,
       module,
       entryPoint,
       signerLaunchpad,
@@ -43,7 +43,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
 
   describe('executeUserOp - new account', () => {
     it('should execute user operation', async () => {
-      const { user, proxyFactory, addModulesLib, module, entryPoint, signerLaunchpad, singleton, signerFactory, navigator } =
+      const { user, proxyFactory, safeModuleSetup, module, entryPoint, signerLaunchpad, singleton, signerFactory, navigator } =
         await setupTests()
 
       const credential = navigator.credentials.create({
@@ -69,8 +69,8 @@ describe('Safe4337Module - WebAuthn Owner', () => {
         singleton: singleton.target,
         signerFactory: signerFactory.target,
         signerData,
-        setupTo: addModulesLib.target,
-        setupData: addModulesLib.interface.encodeFunctionData('enableModules', [[module.target]]),
+        setupTo: safeModuleSetup.target,
+        setupData: safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]]),
         fallbackHandler: module.target,
       }
       const safeInitHash = ethers.TypedDataEncoder.hash(
@@ -197,7 +197,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
 
   describe('executeUserOp - existing account', () => {
     it('should execute user operation', async () => {
-      const { user, proxyFactory, addModulesLib, module, entryPoint, singleton, signerFactory, navigator } = await setupTests()
+      const { user, proxyFactory, safeModuleSetup, module, entryPoint, singleton, signerFactory, navigator } = await setupTests()
       const credential = navigator.credentials.create({
         publicKey: {
           rp: {
@@ -223,7 +223,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
         entryPoint: await entryPoint.getAddress(),
         erc4337module: await module.getAddress(),
         proxyFactory: await proxyFactory.getAddress(),
-        addModulesLib: await addModulesLib.getAddress(),
+        safeModuleSetup: await safeModuleSetup.getAddress(),
         proxyCreationCode: await proxyFactory.proxyCreationCode(),
         chainId: Number(await chainId()),
       })

--- a/modules/4337/test/erc4337/ReferenceEntryPoint.spec.ts
+++ b/modules/4337/test/erc4337/ReferenceEntryPoint.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 import { time } from '@nomicfoundation/hardhat-network-helpers'
 import { EventLog, Log } from 'ethers'
-import { deployReferenceEntryPoint, getFactory, getAddModulesLib } from '../utils/setup'
+import { deployReferenceEntryPoint, getFactory, getSafeModuleSetup } from '../utils/setup'
 import { buildContractSignatureBytes, buildSignatureBytes, logGas } from '../../src/utils/execution'
 import {
   buildSafeUserOpTransaction,
@@ -23,7 +23,7 @@ describe('Safe4337Module - Reference EntryPoint', () => {
     const module = await moduleFactory.deploy(await entryPoint.getAddress())
     const proxyFactory = await getFactory()
     const proxyCreationCode = await proxyFactory.proxyCreationCode()
-    const addModulesLib = await getAddModulesLib()
+    const safeModuleSetup = await getSafeModuleSetup()
     const singletonFactory = await ethers.getContractFactory('SafeL2', deployer)
     const singleton = await singletonFactory.deploy()
 
@@ -32,7 +32,7 @@ describe('Safe4337Module - Reference EntryPoint', () => {
       entryPoint: await entryPoint.getAddress(),
       erc4337module: await module.getAddress(),
       proxyFactory: await proxyFactory.getAddress(),
-      addModulesLib: await addModulesLib.getAddress(),
+      safeModuleSetup: await safeModuleSetup.getAddress(),
       proxyCreationCode,
       chainId: Number(await chainId()),
     }

--- a/modules/4337/test/gas/Gas.spec.ts
+++ b/modules/4337/test/gas/Gas.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
-import { getSafe4337Module, getEntryPoint, getFactory, getAddModulesLib, getSafeL2Singleton } from '../utils/setup'
+import { getSafe4337Module, getEntryPoint, getFactory, getSafeModuleSetup, getSafeL2Singleton } from '../utils/setup'
 import { buildSignatureBytes, logGas } from '../../src/utils/execution'
 import { buildUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp } from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
@@ -16,14 +16,14 @@ describe('Gas Metering', () => {
     const module = await getSafe4337Module()
     const proxyFactory = await getFactory()
     const proxyCreationCode = await proxyFactory.proxyCreationCode()
-    const addModulesLib = await getAddModulesLib()
+    const safeModuleSetup = await getSafeModuleSetup()
     const singleton = await getSafeL2Singleton()
     const safe = await Safe4337.withSigner(user.address, {
       safeSingleton: await singleton.getAddress(),
       entryPoint: await entryPoint.getAddress(),
       erc4337module: await module.getAddress(),
       proxyFactory: await proxyFactory.getAddress(),
-      addModulesLib: await addModulesLib.getAddress(),
+      safeModuleSetup: await safeModuleSetup.getAddress(),
       proxyCreationCode,
       chainId: Number(await chainId()),
     })

--- a/modules/4337/test/utils/setup.ts
+++ b/modules/4337/test/utils/setup.ts
@@ -39,9 +39,9 @@ export const getSafeTemplate = async (for4337 = false, saltNumber = getRandomInt
   return await ethers.getContractAt(for4337 ? 'Safe4337Mock' : 'SafeMock', template)
 }
 
-export const getAddModulesLib = async () => {
-  const LibDeployment = await deployments.get('AddModulesLib')
-  return await ethers.getContractAt('AddModulesLib', LibDeployment.address)
+export const getSafeModuleSetup = async () => {
+  const { address } = await deployments.get('SafeModuleSetup')
+  return await ethers.getContractAt('SafeModuleSetup', address)
 }
 
 export const getSafe4337Module = async () => {


### PR DESCRIPTION
This PR contains fixes to 3 issues from the audit report. They were combined into a single PR in order to prevent git merge conflicts once the review is complete. Each fix is in an individual commit to facilitate the review.

# L-03 - Add Missing DocStrings

There were missing NatSpec documents for both the `SafeModuleSetup` (formerly `AddModulesLib`) contract and `enableModules` function. Both were added to ensure high quality documentation.

# N-01 - Improve `enableModules` Implementation

The `enableModules` function used a reverse loop to go through the modules to add. This was done in order to preserve module order and _thought_ to be slightly more gas efficient. It turns out to not be the case with the current compiler and flags. The loop was changed into a forward loop, making both the implementation more clear, but also slightly more gas efficient.

# N-02 - Rename `AddModulesLib`

The module name could be misconstrued to imply that it was a Solidity library, while it is in fact a contract (the `-Lib` was intended to indicate it was a "library" in the Safe sense of the word). The contract was renamed to more clearly state it purpose: enable modules during Safe setup.

