### PR TITLE
[N-06] Consistent Named Returns

### DIFF
--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -150,10 +150,10 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
 
     /**
      * @notice Computes the 32-byte domain separator used in EIP-712 signature verification for Safe operations.
-     * @return The EIP-712 domain separator hash for this contract.
+     * @return domainSeparatorHash The EIP-712 domain separator hash for this contract.
      */
-    function domainSeparator() public view returns (bytes32) {
-        return keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, block.chainid, this));
+    function domainSeparator() public view returns (bytes32 domainSeparatorHash) {
+        domainSeparatorHash = keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, block.chainid, this));
     }
 
     /**


### PR DESCRIPTION
This PR makes the use of named returns consistent throughout the module contract. In particular, `domainSeparator` is the only function to not use named returns in the `Safe4337Module` contract.