### PR TITLE
[N-04] Add Security Contact to NatSpec

### DIFF
--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -18,6 +18,7 @@ import {ISafe} from "./interfaces/Safe.sol";
  *      - The user operation hash is signed by the Safe owner(s) and validated by the module.
  *      - The user operation is not allowed to execute any other function than `executeUserOp` and `executeUserOpWithErrorString`.
  *      - Replay protection is handled by the entry point.
+ * @custom:security-contact bounty@safe.global
  */
 contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandler {
     /**


### PR DESCRIPTION
Fixes audit issue N-04.

This PR adds the custom `security-contact` tag to the `Safe4337Module` contract NatSpec documentation.

Note that the audit issue additionally mentioned that the `AddModulesLib` contract also needed a security contract, but this was added as part of the NatSpec documentation when resolving L-03 in #241.