### PR TITLE
[M-01] Potential Obsolescence for `Safe4337Module`

### DIFF
--- a/.github/workflows/ci_4337_upstream_bundler.yml
+++ b/.github/workflows/ci_4337_upstream_bundler.yml
@@ -1,0 +1,21 @@
+name: 4337 Module End-to-End Tests With Upstream Bundler
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # There's no direct way to schedule the job run every 2 weeks, instead we schedule it on the 1st and 15th of every month. The trick is taken from https://stackoverflow.com/a/46233330/7820085
+    - cron: '30 1 1,15 * *'
+  push:
+
+jobs:
+  e2e-upstream-bundler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: |
+          npm ci
+          npm run test:e2e:upstream -w modules/4337

--- a/modules/4337/docker-compose.yaml
+++ b/modules/4337/docker-compose.yaml
@@ -22,3 +22,14 @@ services:
     command: ['--auto', '--network=http://geth:8545']
     ports:
       - 3000:3000
+
+  bundler-upstream:
+    build:
+      context: .
+      dockerfile: docker/bundler/Dockerfile
+      args:
+        TAG: main
+    restart: always
+    command: ['--auto', '--network=http://geth:8545']
+    ports:
+      - 3000:3000

--- a/modules/4337/docker/bundler/Dockerfile
+++ b/modules/4337/docker/bundler/Dockerfile
@@ -1,8 +1,9 @@
 FROM docker.io/library/node:18
 
+ARG TAG=v0.6.1
 RUN git clone https://github.com/eth-infinitism/bundler /src/bundler
 WORKDIR /src/bundler
-RUN git checkout v0.6.1
+RUN git checkout ${TAG}
 
 RUN yarn && yarn preprocess
 ENTRYPOINT ["yarn", "bundler"]

--- a/modules/4337/package.json
+++ b/modules/4337/package.json
@@ -18,6 +18,7 @@
     "build:ts": "npx rimraf dist && tsc",
     "test": "hardhat test --deploy-fixture",
     "test:e2e": "./test/e2e/run.sh",
+    "test:e2e:upstream": "USE_UPSTREAM_BUNDLER=1 ./test/e2e/run.sh",
     "test:all": "npm run test && npm run test:e2e",
     "coverage": "hardhat coverage --network hardhat",
     "benchmark": "npm run test benchmark/*.ts",

--- a/modules/4337/test/e2e/run.sh
+++ b/modules/4337/test/e2e/run.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-docker compose up -d
+bundler_container="bundler"
+
+if [[ -n "$USE_UPSTREAM_BUNDLER" ]]; then
+    bundler_container="bundler-upstream"
+fi
+
+docker compose up -d geth "$bundler_container"
 # wait for containers to start up
 SECONDS=0
 until curl -fs http://localhost:8545 >/dev/null && curl -fs http://localhost:3000 >/dev/null; do


### PR DESCRIPTION
As vaguely explained by the OpenZeppelin team, the primary motivation for M-01 is not compatibility with unreleased versions but a more prompt awareness of the new potential changes in the ERC-4337 standard, as they deemed incompatibility with the standard as one of the leading security concerns for the protocol.

This PR presents an alternative solution for M-01 by adding a secondary e2e test job that uses an upstream version of the bundler for the test. This should test both the `Entrypoint <> Module` API compatibility (because the bundler will deploy its own Entrypoint to the locally running geth chain) as well as the storage access rules. The test also runs on schedule (1st and 15th of each month)