### PR TITLE
[N-05] Use Custom Errors Instead of Revert Strings

### DIFF
--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -69,12 +69,46 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
     }
 
     /**
+     * @notice An error indicating that the entry point used when deploying a new module instance is invalid.
+     */
+    error InvalidEntryPoint();
+
+    /**
+     * @notice An error indicating that the caller does not match the Safe in the corresponding user operation.
+     * @dev This indicates that the module is being used to validate a user operation for a Safe that did not directly
+     * call this module.
+     */
+    error InvalidCaller();
+
+    /**
+     * @notice An error indicating that the call validating or executing a user operation was not called by the
+     * supported entry point contract.
+     */
+    error UnsupportedEntryPoint();
+
+    /**
+     * @notice An error indicating that the user operation `callData` does not correspond to one of the two supported
+     * execution functions: `executeUserOp` or `executeUserOpWithErrorString`.
+     */
+    error UnsupportedExecutionFunction(bytes4 selector);
+
+    /**
+     * @notice An error indicating that the user operation failed to execute successfully.
+     * @dev The contract reverts with this error when `executeUserOp` is used instead of bubbling up the original revert
+     * data. When bubbling up revert data is desirable, `executeUserOpWithErrorString` should be used instead.
+     */
+    error ExecutionFailed();
+
+    /**
      * @notice The EIP-712 type-hash for the domain separator used for verifying Safe operation signatures.
      */
     address public immutable SUPPORTED_ENTRYPOINT;
 
     constructor(address entryPoint) {
-        require(entryPoint != address(0), "Invalid entry point");
+        if (entryPoint == address(0)) {
+            revert InvalidEntryPoint();
+        }
+
         SUPPORTED_ENTRYPOINT = entryPoint;
     }
 
@@ -82,7 +116,9 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @notice Validates the call is initiated by the entry point.
      */
     modifier onlySupportedEntryPoint() {
-        require(_msgSender() == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
+        if (_msgSender() != SUPPORTED_ENTRYPOINT) {
+            revert UnsupportedEntryPoint();
+        }
         _;
     }
 
@@ -99,14 +135,16 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
         // The entry point address is appended to the calldata in `HandlerContext` contract
         // Because of this, the relayer may manipulate the entry point address, therefore we have to verify that
         // the sender is the Safe specified in the userOperation
-        require(safeAddress == msg.sender, "Invalid caller");
+        if (safeAddress != msg.sender) {
+            revert InvalidCaller();
+        }
 
         // We check the execution function signature to make sure the entry point can't call any other function
         // and make sure the execution of the user operation is handled by the module
-        require(
-            this.executeUserOp.selector == bytes4(userOp.callData) || this.executeUserOpWithErrorString.selector == bytes4(userOp.callData),
-            "Unsupported execution function id"
-        );
+        bytes4 selector = bytes4(userOp.callData);
+        if (selector != this.executeUserOp.selector && selector != this.executeUserOpWithErrorString.selector) {
+            revert UnsupportedExecutionFunction(selector);
+        }
 
         // The userOp nonce is validated in the entry point (for 0.6.0+), therefore we will not check it again
         validationData = _validateSignatures(userOp);
@@ -128,7 +166,9 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @param operation Operation type of the user operation.
      */
     function executeUserOp(address to, uint256 value, bytes memory data, uint8 operation) external onlySupportedEntryPoint {
-        require(ISafe(msg.sender).execTransactionFromModule(to, value, data, operation), "Execution failed");
+        if (!ISafe(msg.sender).execTransactionFromModule(to, value, data, operation)) {
+            revert ExecutionFailed();
+        }
     }
 
     /**


### PR DESCRIPTION
This PR addresses issue N-05 from the audit report.

In particular this PR changes the Safe 4337 module contract to use custom error codes instead of revert messages. This has a positive impact on the code size of the contracts.

That being said, the 4337 entry point contract v0.6.0 [has special support](https://github.com/eth-infinitism/account-abstraction/blob/abff2aca61a8f0934e533d0d352978055fddbd96/contracts/core/EntryPoint.sol#L410-L417) for revert strings, and as such **I do not believe this to be a positive change** in the context that the 4337 module is designed to work for the v0.6.0 contracts. In particular, we believe that _prioritizing debuggability is more important than contract code size improvements or potential gas savings **in the error paths**_. With that in mind, **I would recommend this change to not be included for the module supporting the v0.6.0 version of the entry point contract**.

However, the special support in the entry point contract with revert string was removed in recent versions of the contract. As of yet, v0.7.0 is unreleased, but these changes **should** be included when the module is upgraded to v0.7.0 of the contracts once released.