### PR TITLE
[N-03] Implement Modifier as Function To Reduce Bytecode Size

### DIFF
--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -82,7 +82,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @notice Validates the call is initiated by the entry point.
      */
     modifier onlySupportedEntryPoint() {
-        require(_msgSender() == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
+        _onlySupportedEntryPoint();
         _;
     }
 
@@ -243,5 +243,12 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
 
             operationData = abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator(), safeOpStructHash);
         }
+    }
+
+    /**
+     * @dev This function reverts if the ERC-2771 passed caller is not the supported entry point.
+     */
+    function _onlySupportedEntryPoint() private view {
+        require(_msgSender() == SUPPORTED_ENTRYPOINT, "Unsupported entry point");
     }
 }


### PR DESCRIPTION
This PR addresses issue N-03 from the audit report.

In particular this PR implements the `onlySupportedEntryPoint` modifier as a call to an internal function to prevent inlining of the modifier implementation in its 3 occurrences. This has a substantial impact to code size of the module.

That being said, **I believe this issue to be invalid in the context of the module**. In particular, while the code size is increased, it also increase gas costs of the `validateUserOp` and `executeUserOp` functions that are called as part of the 4337 user operation flow. Seeing as this module is to be shared across all Safes, we believe that an increase in a one time deployment cost to be the correct trade off in order to allow for gas savings in commonly used functions.

Looking at the numbers:

|                              | Before | After | Gas Improvement                         |
| ---------------------------- | ------ | ----- | --------------------------------------- |
| Code size                    | 8492   | 8124  | (8492 - 8124) * (200 + 16) [^2] = 79488 |
| Token transfer gas cost [^1] | 94439  | 94461 | -22                                     |

With this in mind, this means that after just `ceil(79488 / 22) = 3614` user operations across **all Safes**, paying for the additional code at deployment will be more efficient overall than paying for additional gas fees per user operation. This number would only be further reduced by #247.

[^1]: <https://github.com/safe-global/safe-modules/blob/abfafdcb3cafdfc29a382a5f3dafd349894a4793/modules/4337/test/gas/Gas.spec.ts#L248>
[^2]: Assumes the cost of 1 byte of non-zero calldata in the contract creation transaction plus 1 byte of code stored in state on Ethereum, costs may vary on other networks.
