### PR TITLE
Refactor WebAuthn Signature Validation Logic

### DIFF
--- a/modules/4337/contracts/experimental/SafeSignerLaunchpad.sol
+++ b/modules/4337/contracts/experimental/SafeSignerLaunchpad.sol
@@ -28,7 +28,7 @@ interface IUniqueSignerFactory {
      * @notice Verifies a signature for the specified address without deploying it.
      * @dev This must be equivalent to first deploying the signer with the factory, and then verifying the signature
      * with it directly: `factory.createSigner(signerData).isValidSignature(message, signature)`
-     * @param message The singing message.
+     * @param message The signed message.
      * @param signature The signature bytes.
      * @param signerData The signer data to verify signature for.
      * @return magicValue Returns a legacy EIP-1271 magic value (`bytes4(keccak256(isValidSignature(bytes,bytes))`) when the signature is valid. Reverting or returning any other value implies an invalid signature.

--- a/modules/4337/contracts/experimental/SignatureValidator.sol
+++ b/modules/4337/contracts/experimental/SignatureValidator.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import {SignatureValidatorConstants} from "./SignatureValidatorConstants.sol";
+
+/**
+ * @title ISafeSigner
+ * @dev A interface for smart contract Safe owners that supports multiple `isValidSignature` versions.
+ */
+abstract contract SignatureValidator is SignatureValidatorConstants {
+    /**
+     * @dev Validates the signature for the given data.
+     * @param data The signed data bytes.
+     * @param signature The signature to be validated.
+     * @return magicValue The magic value indicating the validity of the signature.
+     */
+    function isValidSignature(bytes memory data, bytes calldata signature) external view returns (bytes4 magicValue) {
+        if (_verifySignature(keccak256(data), signature)) {
+            magicValue = LEGACY_EIP1271_MAGIC_VALUE;
+        }
+    }
+
+    /**
+     * @dev Validates the signature for a given data hash.
+     * @param message The signing message.
+     * @param signature The signature to be validated.
+     * @return magicValue The magic value indicating the validity of the signature.
+     */
+    function isValidSignature(bytes32 message, bytes calldata signature) external view returns (bytes4 magicValue) {
+        if (_verifySignature(message, signature)) {
+            magicValue = EIP1271_MAGIC_VALUE;
+        }
+    }
+
+    /**
+     * @dev Verifies a signature.
+     * @param message The signing message.
+     * @param signature The signature to be validated.
+     * @return isValid Whether or not the signature is valid.
+     */
+    function _verifySignature(bytes32 message, bytes calldata signature) internal view virtual returns (bool isValid);
+}


### PR DESCRIPTION
This PR slightly refactors the WebAuthn signature validation logic in preparation for sharing code when implementing #228.

Essentially, it creates a `SignatureValidator` abstract base class for sharing that supports both legacy and current EIP-1271 functions. As a consequence of the refactoring, `ISafeSingletonSigner` now uses `bytes32` messages for signature validation instead of `bytes memory`, in order to be more of an analogy to the current EIP-1271 standard (instead of the legacy one).