### PR TITLE
Allow Specifying Docker CLI For E2E

### DIFF
--- a/modules/4337/test/e2e/run.sh
+++ b/modules/4337/test/e2e/run.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 
-bundler_container="bundler"
+DOCKER="${DOCKER:-docker}"
 
+bundler_container="bundler"
 if [[ -n "$USE_UPSTREAM_BUNDLER" ]]; then
     bundler_container="bundler-upstream"
 fi
 
-docker compose up -d geth "$bundler_container"
+"$DOCKER" compose up -d geth "$bundler_container"
+
 # wait for containers to start up
 SECONDS=0
 until curl -fs http://localhost:8545 >/dev/null && curl -fs http://localhost:3000 >/dev/null; do
     if [[ $SECONDS -gt 30 ]]; then
         echo "ERROR: timeout waiting for local node and bundler to start"
-        docker compose logs
+        "$DOCKER" compose logs
         exit 1
     fi
     sleep 1
@@ -20,4 +22,4 @@ done
 
 hardhat test --deploy-fixture --network localhost --grep '^E2E - '
 
-docker compose down
+"$DOCKER" compose down


### PR DESCRIPTION
This PR modifies the E2E `run.sh` script to allow configuration of the Docker CLI to use. Why? I use `podman` instead of `docker`. Another potential use case would be to use a specific `docker` client instead of the one configured in `$PATH`.

I can now successfully run:

```
DOCKER=podman npm run test:e2e
```

Note that not specifying any configuration in the environment will cause the script to default ot the `docker` command. On my system without `docker` installed:

```
$ npm run test:e2e

> @safe-global/safe-erc4337@0.2.0 test:e2e
> ./test/e2e/run.sh

./test/e2e/run.sh: line 5: docker: command not found
```