### PR TITLE
Fix Lint Warnings And Other Small Cleanups

### DIFF
--- a/modules/4337/contracts/experimental/SignatureValidator.sol
+++ b/modules/4337/contracts/experimental/SignatureValidator.sol
@@ -22,7 +22,7 @@ abstract contract SignatureValidator is SignatureValidatorConstants {
 
     /**
      * @dev Validates the signature for a given data hash.
-     * @param message The signing message.
+     * @param message The signed message.
      * @param signature The signature to be validated.
      * @return magicValue The magic value indicating the validity of the signature.
      */
@@ -34,7 +34,7 @@ abstract contract SignatureValidator is SignatureValidatorConstants {
 
     /**
      * @dev Verifies a signature.
-     * @param message The signing message.
+     * @param message The signed message.
      * @param signature The signature to be validated.
      * @return isValid Whether or not the signature is valid.
      */

--- a/modules/4337/contracts/experimental/WebAuthnSigner.sol
+++ b/modules/4337/contracts/experimental/WebAuthnSigner.sol
@@ -100,7 +100,7 @@ contract WebAuthnSignerFactory is IUniqueSignerFactory, SignatureValidatorConsta
 
     /**
      * @dev Checks if the provided signature is valid for the given signer.
-     * @param message The signing message.
+     * @param message The signed message.
      * @param signature The signature to be verified.
      * @param signerData The data used to identify the signer. In this case, the X and Y coordinates of the signer.
      * @return magicValue The magic value indicating the validity of the signature.

--- a/modules/4337/contracts/experimental/verifiers/P256Verifier.sol
+++ b/modules/4337/contracts/experimental/verifiers/P256Verifier.sol
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable no-complex-fallback */
+/* solhint-disable payable-fallback */
 pragma solidity >=0.8.0;
 
 import {FCL_ecdsa} from "../../vendor/FCL/FCL_ecdsa.sol";
@@ -9,7 +11,7 @@ import {FCL_ecdsa} from "../../vendor/FCL/FCL_ecdsa.sol";
  * The contract provides a fallback function that takes a specific input format and returns a result indicating
  * whether the signature is valid or not.
  * The input format is as follows:
- * - input[  0: 32] = signed data hash
+ * - input[  0: 32] = signed message
  * - input[ 32: 64] = signature r
  * - input[ 64: 96] = signature s
  * - input[ 96:128] = public key x
@@ -23,12 +25,12 @@ contract P256Verifier {
             return abi.encodePacked(uint256(0));
         }
 
-        bytes32 hash = bytes32(input[0:32]);
+        bytes32 message = bytes32(input[0:32]);
         uint256 r = uint256(bytes32(input[32:64]));
         uint256 s = uint256(bytes32(input[64:96]));
         uint256 x = uint256(bytes32(input[96:128]));
         uint256 y = uint256(bytes32(input[128:160]));
 
-        return abi.encode(FCL_ecdsa.ecdsa_verify(hash, r, s, x, y));
+        return abi.encode(FCL_ecdsa.ecdsa_verify(message, r, s, x, y));
     }
 }

--- a/modules/4337/contracts/experimental/verifiers/P256Wrapper.sol
+++ b/modules/4337/contracts/experimental/verifiers/P256Wrapper.sol
@@ -10,7 +10,7 @@ pragma solidity >=0.8.0 <0.9.0;
  * @custom:acknowledgement The contract is heavily inspired by https://github.com/daimo-eth/p256-verifier
  */
 contract P256Wrapper {
-    address immutable VERIFIER;
+    address public immutable VERIFIER;
 
     constructor(address verifier) {
         require(verifier != address(0), "P256: invalid verifier address");
@@ -18,20 +18,11 @@ contract P256Wrapper {
     }
 
     /// P256 curve order n/2 for malleability check
-    uint256 constant P256_N_DIV_2 = 57896044605178124381348723474703786764998477612067880171211129530534256022184;
+    uint256 internal constant _P256_N_DIV_2 = 57896044605178124381348723474703786764998477612067880171211129530534256022184;
 
     /**
      * @dev Verifies the signature of a message using P256 elliptic curve.
-     * @param message_hash The hash of the message to be verified.
-     * @param r The r component of the signature.
-     * @param s The s component of the signature.
-     * @param x The x coordinate of the public key.
-     * @param y The y coordinate of the public key.
-     * @return A boolean indicating whether the signature is valid or not.
-     */
-    /**
-     * @dev Verifies the signature of a message using P256 elliptic curve.
-     * @param message_hash The hash of the message to be verified.
+     * @param message The signed message.
      * @param r The r component of the signature.
      * @param s The s component of the signature.
      * @param x The x coordinate of the public key.
@@ -39,7 +30,7 @@ contract P256Wrapper {
      * @return success A boolean indicating whether the signature is valid or not.
      */
     function verifySignatureAllowMalleability(
-        bytes32 message_hash,
+        bytes32 message,
         uint256 r,
         uint256 s,
         uint256 x,
@@ -47,10 +38,11 @@ contract P256Wrapper {
     ) public view returns (bool success) {
         address verifier = VERIFIER;
 
+        // solhint-disable-next-line no-inline-assembly
         assembly ("memory-safe") {
             // Prepare input for staticcall
             let input := mload(0x40) // Free memory pointer
-            mstore(input, message_hash)
+            mstore(input, message)
             mstore(add(input, 32), r)
             mstore(add(input, 64), s)
             mstore(add(input, 96), x)
@@ -73,19 +65,19 @@ contract P256Wrapper {
 
     /**
      * @dev Verifies the signature of a message using the P256 elliptic curve.
-     * @param message_hash The hash of the message to be verified.
+     * @param message The signed message.
      * @param r The r component of the signature.
      * @param s The s component of the signature.
      * @param x The x coordinate of the public key.
      * @param y The y coordinate of the public key.
-     * @return A boolean indicating whether the signature is valid.
+     * @return success A boolean indicating whether the signature is valid or not.
      */
-    function verifySignature(bytes32 message_hash, uint256 r, uint256 s, uint256 x, uint256 y) internal view returns (bool) {
+    function verifySignature(bytes32 message, uint256 r, uint256 s, uint256 x, uint256 y) internal view returns (bool success) {
         // check for signature malleability
-        if (s > P256_N_DIV_2) {
+        if (s > _P256_N_DIV_2) {
             return false;
         }
 
-        return verifySignatureAllowMalleability(message_hash, r, s, x, y);
+        success = verifySignatureAllowMalleability(message, r, s, x, y);
     }
 }

--- a/modules/4337/contracts/experimental/verifiers/WebAuthnVerifier.sol
+++ b/modules/4337/contracts/experimental/verifiers/WebAuthnVerifier.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+/* solhint-disable one-contract-per-file */
 pragma solidity >=0.8.0;
 
 import {P256Wrapper} from "./P256Wrapper.sol";
@@ -17,10 +18,10 @@ library WebAuthnConstants {
      * - `AUTH_DATA_FLAGS_BE`: Attested Credential Data (BE) flag in the authenticator data.
      * - `AUTH_DATA_FLAGS_BS`: Extension Data (BS) flag in the authenticator data.
      */
-    bytes1 constant AUTH_DATA_FLAGS_UP = 0x01;
-    bytes1 constant AUTH_DATA_FLAGS_UV = 0x04;
-    bytes1 constant AUTH_DATA_FLAGS_BE = 0x08;
-    bytes1 constant AUTH_DATA_FLAGS_BS = 0x10;
+    bytes1 internal constant AUTH_DATA_FLAGS_UP = 0x01;
+    bytes1 internal constant AUTH_DATA_FLAGS_UV = 0x04;
+    bytes1 internal constant AUTH_DATA_FLAGS_BE = 0x08;
+    bytes1 internal constant AUTH_DATA_FLAGS_BS = 0x10;
 }
 
 /**
@@ -164,13 +165,8 @@ contract WebAuthnVerifier is IWebAuthnVerifier, P256Wrapper {
         uint256 qx,
         uint256 qy
     ) public view returns (bool result) {
-        // check authenticator flags, e.g. for User Presence (0x01) and/or User Verification (0x04)
-        if ((authenticatorData[32] & authenticatorFlags) != authenticatorFlags) {
-            return false;
-        }
-
         // check for signature malleability
-        if (rs[1] > P256_N_DIV_2) {
+        if (rs[1] > _P256_N_DIV_2) {
             return false;
         }
 

--- a/modules/4337/test/e2e/run.sh
+++ b/modules/4337/test/e2e/run.sh
@@ -21,5 +21,9 @@ until curl -fs http://localhost:8545 >/dev/null && curl -fs http://localhost:300
 done
 
 hardhat test --deploy-fixture --network localhost --grep '^E2E - '
+success=$?
 
 "$DOCKER" compose down
+
+# exit with the E2E test's exit code
+exit $success


### PR DESCRIPTION
This PR addresses some lint warnings I found when working on #254. Additionally, I also:
- made the wording around "signed message" more consistent throughout the code
- fixed the E2E Bash script to report errors when tests fail