### PR TITLE
Document supported entrypoint versions

### DIFF
--- a/modules/4337/CHANGELOG.md
+++ b/modules/4337/CHANGELOG.md
@@ -10,6 +10,10 @@ Solidity compiler: [0.8.23](https://github.com/ethereum/solidity/releases/tag/v0
 
 Solidity optimizer: enabled with 10.000.000 runs
 
+## Supported EntryPoint
+
+The official deployments support the EntryPoint v0.6.0 with the canonical deployment at `0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789`.
+
 ## Expected addresses
 
 - `AddModulesLib` at `0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb`

--- a/modules/4337/README.md
+++ b/modules/4337/README.md
@@ -2,6 +2,8 @@
 
 :warning: **This module MUST only be used with Safe 1.4.1 or newer** :warning:
 
+For the supported EntryPoint version, please refer to the [CHANGELOG](./CHANGELOG.md). The module was tested and audited with the EntryPoint version mentioned in the changelog in mind; if you use a different version, you do so at your own risk.
+
 ## Execution Flow
 
 The diagram below outlines the flow triggered when a user operation is submitted to the entrypoint. Additionally, the gas overhead compared to a native implementation is mentioned.


### PR DESCRIPTION
This PR:
- Partially solves https://github.com/safe-global/safe-modules/issues/231 (partially because the issue says 0.7.0 which isn't released yet)
- I decided to include the supported entrypoint version and address in the changelog because the official deployment is tied to a certain entrypoint which, in my opinion, should be documented.