### PR TITLE
Fix Singleton Signer E2E Test Flakiness

### DIFF
--- a/modules/4337/test/e2e/SingletonSigners.spec.ts
+++ b/modules/4337/test/e2e/SingletonSigners.spec.ts
@@ -113,7 +113,7 @@ describe('E2E - Singleton Signers', () => {
     const signature = buildContractSignatureBytes(
       customSigners.map(({ signer, key }) => ({
         signer: signer.target as string,
-        data: ethers.toBeHex(BigInt(opHash) ^ key),
+        data: ethers.toBeHex(BigInt(opHash) ^ key, 32),
       })),
     )
     const userOp = buildUserOperationFromSafeUserOperation({


### PR DESCRIPTION
The singleton signer E2E test would [sometimes fail](https://github.com/safe-global/safe-modules/actions/runs/7841917436/job/21399201219). Flaky tests are evil...

It turns out that this is for a fairly simple reason. The test singleton signer key is expected to be exactly 32 bytes long:

https://github.com/safe-global/safe-modules/blob/ed765e2e882f3c12d264a45f8152cdcdebb1a216/modules/4337/contracts/test/TestSingletonSigner.sol#L21

Looking at the error output from the above test, we see that one of the encoded test singleton signer keys was encoded to only be 31 bytes long:

```
000000000000000000000000000000000000000000000000000000000000001f
203a672226f49702ad0b8e30a27ab23729f9d164492e1209008ab1f7763df9
```

This is because we are encoding the signature with `ethers.toBeHex`, which will strip leading 0's unless a `width` parameter is specified. This means that, the signature worked out to having a 00 leading byte, which happens with probability of ~1/256.

The fix is simple: specify a fixed `width` when encoding the key.