### PR TITLE
Sign All Gas Limit and Price Parameters

### DIFF
--- a/modules/4337/contracts/test/SafeMock.sol
+++ b/modules/4337/contracts/test/SafeMock.sol
@@ -99,13 +99,9 @@ contract SafeMock {
 contract Safe4337Mock is SafeMock, IAccount {
     using UserOperationLib for PackedUserOperation;
 
-    /// keccak256("EIP712Domain(uint256 chainId,address verifyingContract)") = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218
     bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
 
-    // keccak256(
-    //     "SafeOp("SafeOp(address safe,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,bytes paymasterAndData,uint48 validAfter,uint48 validUntil,address entryPoint)"
-    // ) = 0x9efbfd16c059a992a21cba49ddec650b37de25cf6baa04788c16c00b47bb62de
-    bytes32 private constant SAFE_OP_TYPEHASH = 0x9efbfd16c059a992a21cba49ddec650b37de25cf6baa04788c16c00b47bb62de;
+    bytes32 private constant SAFE_OP_TYPEHASH = 0xc03dfc11d8b10bf9cf703d558958c8c42777f785d998c62060d85a4f0ef6ea7f;
 
     /**
      * @dev A structure used internally for manually encoding a Safe operation for when computing the EIP-712 struct hash.
@@ -116,10 +112,11 @@ contract Safe4337Mock is SafeMock, IAccount {
         uint256 nonce;
         bytes32 initCodeHash;
         bytes32 callDataHash;
-        bytes32 accountGasLimits;
+        uint128 verificationGasLimit;
+        uint128 callGasLimit;
         uint256 preVerificationGas;
-        uint256 maxFeePerGas;
-        uint256 maxPriorityFeePerGas;
+        uint128 maxPriorityFeePerGas;
+        uint128 maxFeePerGas;
         bytes32 paymasterAndDataHash;
         uint48 validAfter;
         uint48 validUntil;
@@ -255,10 +252,11 @@ contract Safe4337Mock is SafeMock, IAccount {
                 nonce: userOp.nonce,
                 initCodeHash: keccak256(userOp.initCode),
                 callDataHash: keccak256(userOp.callData),
-                accountGasLimits: userOp.accountGasLimits,
+                verificationGasLimit: uint128(userOp.unpackVerificationGasLimit()),
+                callGasLimit: uint128(userOp.unpackCallGasLimit()),
                 preVerificationGas: userOp.preVerificationGas,
-                maxFeePerGas: userOp.maxFeePerGas,
-                maxPriorityFeePerGas: userOp.maxPriorityFeePerGas,
+                maxPriorityFeePerGas: uint128(userOp.unpackMaxPriorityFeePerGas()),
+                maxFeePerGas: uint128(userOp.unpackMaxFeePerGas()),
                 paymasterAndDataHash: keccak256(userOp.paymasterAndData),
                 validAfter: validAfter,
                 validUntil: validUntil,
@@ -270,8 +268,8 @@ contract Safe4337Mock is SafeMock, IAccount {
             assembly ("memory-safe") {
                 // Since the `encodedSafeOp` value's memory layout is identical to the result of `abi.encode`-ing the
                 // individual `SafeOp` fields, we can pass it directly to `keccak256`. Additionally, there are 13
-                // 32-byte fields to hash, for a length of `13 * 32 = 448` bytes.
-                safeOpStructHash := keccak256(encodedSafeOp, 416)
+                // 32-byte fields to hash, for a length of `14 * 32 = 448` bytes.
+                safeOpStructHash := keccak256(encodedSafeOp, 448)
             }
 
             operationData = abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator(), safeOpStructHash);

--- a/modules/4337/package.json
+++ b/modules/4337/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/safe-global/safe-modules/issues"
   },
   "devDependencies": {
-    "@account-abstraction/contracts": "github:5afe/account-abstraction#a476d9da6342cf827d0a458c2fb6356e0f015342",
+    "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-12",
     "@noble/curves": "^1.3.0",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@openzeppelin/contracts": "^5.0.0",

--- a/modules/4337/scripts/runOp.ts
+++ b/modules/4337/scripts/runOp.ts
@@ -1,7 +1,7 @@
-import { BigNumberish, Result } from 'ethers'
+import { Result } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { getRequiredPrefund, getSupportedEntryPoints } from '../src/utils/userOp'
+import { UserOperation, getRequiredPrefund, getSupportedEntryPoints } from '../src/utils/userOp'
 import { chainId } from '../test/utils/encoding'
 import { getSafe4337Module } from '../test/utils/setup'
 import { GlobalConfig, MultiProvider4337, Safe4337 } from '../src/utils/safe'
@@ -114,7 +114,7 @@ const runOp = async () => {
       {
         from: entryPoint,
         to: safe.address,
-        data: buildData('validateUserOp((address,uint256,bytes,bytes,bytes32,uint256,uint256,uint256,bytes,bytes),bytes32,uint256)', [
+        data: buildData('validateUserOp((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes),bytes32,uint256)', [
           [
             userOp.sender,
             userOp.nonce,
@@ -122,8 +122,7 @@ const runOp = async () => {
             userOp.callData,
             userOp.accountGasLimits,
             userOp.preVerificationGas,
-            userOp.maxFeePerGas,
-            userOp.maxPriorityFeePerGas,
+            userOp.gasFees,
             userOp.paymasterAndData,
             userOp.signature,
           ],

--- a/modules/4337/src/utils/safe.ts
+++ b/modules/4337/src/utils/safe.ts
@@ -2,7 +2,7 @@ import { AddressLike, JsonRpcProvider, Provider, Signer, ethers } from 'ethers'
 
 // Import from Safe contracts repo once fixed
 import { MetaTransaction, SafeSignature, buildSignatureBytes } from './execution'
-import { UserOperation, EIP712_SAFE_OPERATION_TYPE, packAccountGasLimits } from './userOp'
+import { UserOperation, EIP712_SAFE_OPERATION_TYPE, packGasParameters } from './userOp'
 
 const AddressOne = '0x0000000000000000000000000000000000000001'
 
@@ -25,11 +25,11 @@ const INTERFACES = new ethers.Interface([
 export interface OperationParams {
   nonce: bigint
   initCode: string
-  preVerificationGas: bigint
   verificationGasLimit: bigint
   callGasLimit: bigint
-  maxFeePerGas: bigint
+  preVerificationGas: bigint
   maxPriorityFeePerGas: bigint
+  maxFeePerGas: bigint
   paymasterAndData: string
   validAfter: bigint
   validUntil: bigint
@@ -157,13 +157,13 @@ export class Safe4337Operation {
   }
 
   async userOperation(paymasterAndData = '0x'): Promise<UserOperation> {
+    const { accountGasLimits, gasFees } = packGasParameters(this.params)
     return {
       nonce: ethers.toBeHex(this.params.nonce),
       callData: actionCalldata(this.action),
-      accountGasLimits: packAccountGasLimits(this.params.verificationGasLimit, this.params.callGasLimit),
+      accountGasLimits: ethers.hexlify(accountGasLimits),
       preVerificationGas: ethers.toBeHex(this.params.preVerificationGas),
-      maxFeePerGas: ethers.toBeHex(this.params.maxFeePerGas),
-      maxPriorityFeePerGas: ethers.toBeHex(this.params.maxPriorityFeePerGas),
+      gasFees: ethers.hexlify(gasFees),
       initCode: this.params.initCode,
       paymasterAndData,
       sender: this.safe.address,

--- a/modules/4337/test/e2e/UniqueSigner.spec.ts
+++ b/modules/4337/test/e2e/UniqueSigner.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { deployments, ethers, network } from 'hardhat'
 import { bundlerRpc, prepareAccounts, waitForUserOp } from '../utils/e2e'
 import { chainId } from '../utils/encoding'
-import { packAccountGasLimits } from '../../src/utils/userOp'
+import { packGasParameters } from '../../src/utils/userOp'
 
 describe('E2E - Unique Signers', () => {
   before(function () {
@@ -111,10 +111,13 @@ describe('E2E - Unique Signers', () => {
         safeInit.fallbackHandler,
         module.interface.encodeFunctionData('executeUserOp', [user.address, ethers.parseEther('0.5'), '0x', 0]),
       ]),
-      accountGasLimits: packAccountGasLimits(500000, 2000000),
       preVerificationGas: ethers.toBeHex(60000),
-      maxFeePerGas: ethers.toBeHex(10000000000),
-      maxPriorityFeePerGas: ethers.toBeHex(10000000000),
+      ...packGasParameters({
+        verificationGasLimit: 500000,
+        callGasLimit: 2000000,
+        maxFeePerGas: 10000000000,
+        maxPriorityFeePerGas: 10000000000,
+      }),
       paymasterAndData: '0x',
     }
 

--- a/modules/4337/test/e2e/WebAuthnSigner.spec.ts
+++ b/modules/4337/test/e2e/WebAuthnSigner.spec.ts
@@ -9,7 +9,7 @@ import {
   extractPublicKey,
   extractSignature,
 } from '../utils/webauthn'
-import { packAccountGasLimits } from '../../src/utils/userOp'
+import { packGasParameters } from '../../src/utils/userOp'
 
 describe('E2E - WebAuthn Signers', () => {
   before(function () {
@@ -153,10 +153,13 @@ describe('E2E - WebAuthn Signers', () => {
         safeInit.fallbackHandler,
         module.interface.encodeFunctionData('executeUserOp', [user.address, ethers.parseEther('0.5'), '0x', 0]),
       ]),
-      accountGasLimits: packAccountGasLimits(500000, 2000000),
       preVerificationGas: ethers.toBeHex(60000),
-      maxFeePerGas: ethers.toBeHex(10000000000),
-      maxPriorityFeePerGas: ethers.toBeHex(10000000000),
+      ...packGasParameters({
+        verificationGasLimit: 500000,
+        callGasLimit: 2000000,
+        maxFeePerGas: 10000000000,
+        maxPriorityFeePerGas: 10000000000,
+      }),
       paymasterAndData: '0x',
     }
 

--- a/modules/4337/test/e2e/WebAuthnSingletonSigner.spec.ts
+++ b/modules/4337/test/e2e/WebAuthnSingletonSigner.spec.ts
@@ -8,7 +8,7 @@ import {
   extractPublicKey,
   extractSignature,
 } from '../utils/webauthn'
-import { buildSafeUserOpTransaction, buildUserOperationFromSafeUserOperation, packAccountGasLimits } from '../../src/utils/userOp'
+import { buildSafeUserOpTransaction, buildUserOperationFromSafeUserOperation } from '../../src/utils/userOp'
 import { buildContractSignatureBytes } from '../../src/utils/execution'
 
 describe('E2E - WebAuthn Singleton Signers', () => {
@@ -135,7 +135,7 @@ describe('E2E - WebAuthn Singleton Signers', () => {
       false,
       {
         initCode,
-        accountGasLimits: packAccountGasLimits(700000, 2000000),
+        verificationGasLimit: 700000,
       },
     )
     const opHash = await module.getOperationHash(

--- a/modules/4337/test/erc4337/ERC4337WebAuthn.spec.ts
+++ b/modules/4337/test/erc4337/ERC4337WebAuthn.spec.ts
@@ -6,7 +6,7 @@ import {
   buildSafeUserOpTransaction,
   buildUserOperationFromSafeUserOperation,
   calculateSafeOperationHash,
-  packAccountGasLimits,
+  packGasParameters,
 } from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
 import {
@@ -153,10 +153,13 @@ describe('Safe4337Module - WebAuthn Owner', () => {
           safeInit.fallbackHandler,
           module.interface.encodeFunctionData('executeUserOp', [user.address, ethers.parseEther('0.5'), '0x', 0]),
         ]),
-        accountGasLimits: packAccountGasLimits(500000, 2500000),
         preVerificationGas: ethers.toBeHex(60000),
-        maxFeePerGas: ethers.toBeHex(10000000000),
-        maxPriorityFeePerGas: ethers.toBeHex(10000000000),
+        ...packGasParameters({
+          verificationGasLimit: 500000,
+          callGasLimit: 2500000,
+          maxPriorityFeePerGas: 10000000000,
+          maxFeePerGas: 10000000000,
+        }),
         paymasterAndData: '0x',
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,7 @@
         "@safe-global/safe-contracts": "^1.4.1"
       },
       "devDependencies": {
-        "@account-abstraction/contracts": "github:5afe/account-abstraction#a476d9da6342cf827d0a458c2fb6356e0f015342",
+        "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-12",
         "@noble/curves": "^1.3.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.0",
@@ -288,458 +288,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "modules/4337/node_modules/@account-abstraction/contracts": {
-      "name": "accountabstraction",
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/5afe/account-abstraction.git#a476d9da6342cf827d0a458c2fb6356e0f015342",
-      "integrity": "sha512-e71B2g0kKeZlNGJGWONXg2psRAt7BN/1dapED825urVMUYVzmIfi1bjzZNlNngP/0wCXEiHioiOLiGLkPONvJg==",
-      "dev": true,
-      "dependencies": {
-        "@nomiclabs/hardhat-etherscan": "^2.1.6",
-        "@openzeppelin/contracts": "^5.0.0",
-        "@thehubbleproject/bls": "^0.5.1",
-        "@typechain/hardhat": "^2.3.0",
-        "@types/mocha": "^9.0.0",
-        "ethereumjs-util": "^7.1.0",
-        "ethereumjs-wallet": "^1.0.1",
-        "hardhat-deploy": "^0.11.23",
-        "hardhat-deploy-ethers": "^0.3.0-beta.11",
-        "solidity-coverage": "^0.8.4",
-        "source-map-support": "^0.5.19",
-        "table": "^6.8.0",
-        "typescript": "^4.3.5"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/@nomiclabs/hardhat-etherscan": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.8.tgz",
-      "integrity": "sha512-0+rj0SsZotVOcTLyDOxnOc3Gulo8upo0rsw/h+gBPcmtj91YqYJNhdARHoBxOhhE8z+5IUQPx+Dii04lXT14PA==",
-      "deprecated": "The @nomiclabs/hardhat-etherscan package is deprecated, please use @nomicfoundation/hardhat-verify instead",
-      "dev": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.1.2",
-        "@ethersproject/address": "^5.0.2",
-        "cbor": "^5.0.2",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "node-fetch": "^2.6.0",
-        "semver": "^6.3.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.0.4"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/@nomiclabs/hardhat-etherscan/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/@typechain/hardhat": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-2.3.1.tgz",
-      "integrity": "sha512-BQV8OKQi0KAzLXCdsPO0pZBNQQ6ra8A2ucC26uFX/kquRBtJu1yEyWnVSmtr07b5hyRoJRpzUeINLnyqz4/MAw==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "^9.1.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.0.10",
-        "lodash": "^4.17.15",
-        "typechain": "^5.1.2"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/cbor": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-      "dev": true,
-      "dependencies": {
-        "bignumber.js": "^9.0.1",
-        "nofilter": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/hardhat-deploy-ethers": {
-      "version": "0.3.0-beta.13",
-      "resolved": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz",
-      "integrity": "sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==",
-      "dev": true,
-      "peerDependencies": {
-        "ethers": "^5.0.0",
-        "hardhat": "^2.0.0"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/typechain": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typechain/-/typechain-5.2.0.tgz",
-      "integrity": "sha512-0INirvQ+P+MwJOeMct+WLkUE4zov06QxC96D+i3uGFEHoiSkZN70MKDQsaj8zkL86wQwByJReI2e7fOUwECFuw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prettier": "^2.1.1",
-        "command-line-args": "^4.0.7",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.0",
-        "glob": "^7.1.6",
-        "js-sha3": "^0.8.0",
-        "lodash": "^4.17.15",
-        "mkdirp": "^1.0.4",
-        "prettier": "^2.1.2",
-        "ts-essentials": "^7.0.1"
-      },
-      "bin": {
-        "typechain": "dist/cli/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.1.0"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/typechain/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "modules/4337/node_modules/@account-abstraction/contracts/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "modules/4337/node_modules/@ethersproject/contracts": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.7.0",
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0"
-      }
-    },
-    "modules/4337/node_modules/@ethersproject/hdnode": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/basex": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
-    "modules/4337/node_modules/@ethersproject/json-wallets": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "modules/4337/node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "dev": true,
-      "peer": true
-    },
-    "modules/4337/node_modules/@ethersproject/pbkdf2": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0"
-      }
-    },
-    "modules/4337/node_modules/@ethersproject/solidity": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "modules/4337/node_modules/@ethersproject/units": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "modules/4337/node_modules/@ethersproject/wallet": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/json-wallets": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
-    "modules/4337/node_modules/@ethersproject/wordlists": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
     "modules/4337/node_modules/@noble/hashes": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
@@ -843,19 +391,6 @@
         "typechain": "^8.3.2"
       }
     },
-    "modules/4337/node_modules/array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "typical": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "modules/4337/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -870,21 +405,6 @@
         "node": ">=12"
       }
     },
-    "modules/4337/node_modules/command-line-args": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-back": "^2.0.0",
-        "find-replace": "^1.0.3",
-        "typical": "^2.6.1"
-      },
-      "bin": {
-        "command-line-args": "bin/cli.js"
-      }
-    },
     "modules/4337/node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -892,45 +412,6 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "modules/4337/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "modules/4337/node_modules/ethereumjs-util": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-      "dev": true,
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "modules/4337/node_modules/ethers": {
@@ -979,38 +460,12 @@
       "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
       "dev": true
     },
-    "modules/4337/node_modules/find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "modules/4337/node_modules/find-replace/node_modules/array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "typical": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "modules/4337/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -1026,49 +481,12 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "modules/4337/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "modules/4337/node_modules/nofilter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "modules/4337/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "modules/4337/node_modules/semver": {
@@ -1108,18 +526,12 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "modules/4337/node_modules/typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
-      "dev": true,
-      "peer": true
-    },
     "modules/4337/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1710,6 +1122,254 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@account-abstraction/contracts": {
+      "name": "accountabstraction",
+      "version": "0.6.0",
+      "resolved": "git+ssh://git@github.com/5afe/account-abstraction.git#cb4d0bd5bda5b189c9e228261ac91fe9a83a3542",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nomiclabs/hardhat-etherscan": "^2.1.6",
+        "@openzeppelin/contracts": "^5.0.0",
+        "@thehubbleproject/bls": "^0.5.1",
+        "@typechain/hardhat": "^2.3.0",
+        "@types/debug": "^4.1.12",
+        "@types/mocha": "^9.0.0",
+        "debug": "^4.3.4",
+        "ethereumjs-util": "^7.1.0",
+        "ethereumjs-wallet": "^1.0.1",
+        "hardhat-deploy": "^0.11.23",
+        "hardhat-deploy-ethers": "^0.3.0-beta.11",
+        "solidity-coverage": "^0.8.4",
+        "source-map-support": "^0.5.19",
+        "table": "^6.8.0",
+        "typescript": "^4.3.5"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/@typechain/hardhat": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-2.3.1.tgz",
+      "integrity": "sha512-BQV8OKQi0KAzLXCdsPO0pZBNQQ6ra8A2ucC26uFX/kquRBtJu1yEyWnVSmtr07b5hyRoJRpzUeINLnyqz4/MAw==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.10",
+        "lodash": "^4.17.15",
+        "typechain": "^5.1.2"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/@typechain/hardhat/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/array-back": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "typical": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/command-line-args": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
+      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-back": "^2.0.0",
+        "find-replace": "^1.0.3",
+        "typical": "^2.6.1"
+      },
+      "bin": {
+        "command-line-args": "bin/cli.js"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/ethereumjs-util": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+      "dev": true,
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "rlp": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/find-replace": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+      "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-back": "^1.0.4",
+        "test-value": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/find-replace/node_modules/array-back": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "typical": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/typechain": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-5.2.0.tgz",
+      "integrity": "sha512-0INirvQ+P+MwJOeMct+WLkUE4zov06QxC96D+i3uGFEHoiSkZN70MKDQsaj8zkL86wQwByJReI2e7fOUwECFuw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prettier": "^2.1.1",
+        "command-line-args": "^4.0.7",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.0",
+        "glob": "^7.1.6",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^1.0.4",
+        "prettier": "^2.1.2",
+        "ts-essentials": "^7.0.1"
+      },
+      "bin": {
+        "typechain": "dist/cli/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/typical": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -4819,6 +4479,47 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nomiclabs/hardhat-etherscan": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.8.tgz",
+      "integrity": "sha512-0+rj0SsZotVOcTLyDOxnOc3Gulo8upo0rsw/h+gBPcmtj91YqYJNhdARHoBxOhhE8z+5IUQPx+Dii04lXT14PA==",
+      "deprecated": "The @nomiclabs/hardhat-etherscan package is deprecated, please use @nomicfoundation/hardhat-verify instead",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^5.0.2",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "node-fetch": "^2.6.0",
+        "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.4"
+      }
+    },
+    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/cbor": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
+      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+      "dev": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.1",
+        "nofilter": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/nofilter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@openzeppelin/contracts": {
@@ -12305,6 +12006,16 @@
         "zksync-web3": "^0.14.3"
       }
     },
+    "node_modules/hardhat-deploy-ethers": {
+      "version": "0.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz",
+      "integrity": "sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==",
+      "dev": true,
+      "peerDependencies": {
+        "ethers": "^5.0.0",
+        "hardhat": "^2.0.0"
+      }
+    },
     "node_modules/hardhat-deploy/node_modules/@ethersproject/contracts": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
@@ -19426,6 +19137,202 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
+    "@account-abstraction/contracts": {
+      "version": "git+ssh://git@github.com/5afe/account-abstraction.git#cb4d0bd5bda5b189c9e228261ac91fe9a83a3542",
+      "dev": true,
+      "from": "@account-abstraction/contracts@github:5afe/account-abstraction#prerelease/2024-02-12",
+      "requires": {
+        "@nomiclabs/hardhat-etherscan": "^2.1.6",
+        "@openzeppelin/contracts": "^5.0.0",
+        "@thehubbleproject/bls": "^0.5.1",
+        "@typechain/hardhat": "^2.3.0",
+        "@types/debug": "^4.1.12",
+        "@types/mocha": "^9.0.0",
+        "debug": "^4.3.4",
+        "ethereumjs-util": "^7.1.0",
+        "ethereumjs-wallet": "^1.0.1",
+        "hardhat-deploy": "^0.11.23",
+        "hardhat-deploy-ethers": "^0.3.0-beta.11",
+        "solidity-coverage": "^0.8.4",
+        "source-map-support": "^0.5.19",
+        "table": "^6.8.0",
+        "typescript": "^4.3.5"
+      },
+      "dependencies": {
+        "@typechain/hardhat": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-2.3.1.tgz",
+          "integrity": "sha512-BQV8OKQi0KAzLXCdsPO0pZBNQQ6ra8A2ucC26uFX/kquRBtJu1yEyWnVSmtr07b5hyRoJRpzUeINLnyqz4/MAw==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "^9.1.0"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "9.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+              "dev": true,
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            }
+          }
+        },
+        "@types/mocha": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+          "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+          "dev": true
+        },
+        "array-back": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "typical": "^2.6.1"
+          }
+        },
+        "command-line-args": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
+          "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "array-back": "^2.0.0",
+            "find-replace": "^1.0.3",
+            "typical": "^2.6.1"
+          }
+        },
+        "ethereum-cryptography": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+          "dev": true,
+          "requires": {
+            "@types/pbkdf2": "^3.0.0",
+            "@types/secp256k1": "^4.0.1",
+            "blakejs": "^1.1.0",
+            "browserify-aes": "^1.2.0",
+            "bs58check": "^2.1.2",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "hash.js": "^1.1.7",
+            "keccak": "^3.0.0",
+            "pbkdf2": "^3.0.17",
+            "randombytes": "^2.1.0",
+            "safe-buffer": "^5.1.2",
+            "scrypt-js": "^3.0.0",
+            "secp256k1": "^4.0.1",
+            "setimmediate": "^1.0.5"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+          "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "rlp": "^2.2.4"
+          }
+        },
+        "find-replace": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+          "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "array-back": "^1.0.4",
+            "test-value": "^2.1.0"
+          },
+          "dependencies": {
+            "array-back": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+              "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "typical": "^2.6.0"
+              }
+            }
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true,
+          "peer": true
+        },
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "dev": true,
+          "peer": true
+        },
+        "typechain": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typechain/-/typechain-5.2.0.tgz",
+          "integrity": "sha512-0INirvQ+P+MwJOeMct+WLkUE4zov06QxC96D+i3uGFEHoiSkZN70MKDQsaj8zkL86wQwByJReI2e7fOUwECFuw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@types/prettier": "^2.1.1",
+            "command-line-args": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-extra": "^7.0.0",
+            "glob": "^7.1.6",
+            "js-sha3": "^0.8.0",
+            "lodash": "^4.17.15",
+            "mkdirp": "^1.0.4",
+            "prettier": "^2.1.2",
+            "ts-essentials": "^7.0.1"
+          }
+        },
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        },
+        "typical": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
+          "dev": true,
+          "peer": true
+        },
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+          "dev": true
+        }
+      }
+    },
     "@adraffy/ens-normalize": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
@@ -21546,6 +21453,39 @@
       "dev": true,
       "optional": true
     },
+    "@nomiclabs/hardhat-etherscan": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.8.tgz",
+      "integrity": "sha512-0+rj0SsZotVOcTLyDOxnOc3Gulo8upo0rsw/h+gBPcmtj91YqYJNhdARHoBxOhhE8z+5IUQPx+Dii04lXT14PA==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^5.0.2",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "node-fetch": "^2.6.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "cbor": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
+          "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "^9.0.1",
+            "nofilter": "^1.0.4"
+          }
+        },
+        "nofilter": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+          "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
+          "dev": true
+        }
+      }
+    },
     "@openzeppelin/contracts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.1.tgz",
@@ -22380,7 +22320,7 @@
     "@safe-global/safe-erc4337": {
       "version": "file:modules/4337",
       "requires": {
-        "@account-abstraction/contracts": "github:5afe/account-abstraction#a476d9da6342cf827d0a458c2fb6356e0f015342",
+        "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-12",
         "@noble/curves": "^1.3.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.0",
@@ -22404,335 +22344,6 @@
         "yargs": "^17.5.1"
       },
       "dependencies": {
-        "@account-abstraction/contracts": {
-          "version": "git+ssh://git@github.com/5afe/account-abstraction.git#a476d9da6342cf827d0a458c2fb6356e0f015342",
-          "integrity": "sha512-e71B2g0kKeZlNGJGWONXg2psRAt7BN/1dapED825urVMUYVzmIfi1bjzZNlNngP/0wCXEiHioiOLiGLkPONvJg==",
-          "dev": true,
-          "from": "@account-abstraction/contracts@github:5afe/account-abstraction#a476d9da6342cf827d0a458c2fb6356e0f015342",
-          "requires": {
-            "@nomiclabs/hardhat-etherscan": "^2.1.6",
-            "@openzeppelin/contracts": "^5.0.0",
-            "@thehubbleproject/bls": "^0.5.1",
-            "@typechain/hardhat": "^2.3.0",
-            "@types/mocha": "^9.0.0",
-            "ethereumjs-util": "^7.1.0",
-            "ethereumjs-wallet": "^1.0.1",
-            "hardhat-deploy": "^0.11.23",
-            "hardhat-deploy-ethers": "^0.3.0-beta.11",
-            "solidity-coverage": "^0.8.4",
-            "source-map-support": "^0.5.19",
-            "table": "^6.8.0",
-            "typescript": "^4.3.5"
-          },
-          "dependencies": {
-            "@nomiclabs/hardhat-etherscan": {
-              "version": "2.1.8",
-              "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.8.tgz",
-              "integrity": "sha512-0+rj0SsZotVOcTLyDOxnOc3Gulo8upo0rsw/h+gBPcmtj91YqYJNhdARHoBxOhhE8z+5IUQPx+Dii04lXT14PA==",
-              "dev": true,
-              "requires": {
-                "@ethersproject/abi": "^5.1.2",
-                "@ethersproject/address": "^5.0.2",
-                "cbor": "^5.0.2",
-                "debug": "^4.1.1",
-                "fs-extra": "^7.0.1",
-                "node-fetch": "^2.6.0",
-                "semver": "^6.3.0"
-              },
-              "dependencies": {
-                "fs-extra": {
-                  "version": "7.0.1",
-                  "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-                  "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-                  "dev": true,
-                  "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "jsonfile": "^4.0.0",
-                    "universalify": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "@typechain/hardhat": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-2.3.1.tgz",
-              "integrity": "sha512-BQV8OKQi0KAzLXCdsPO0pZBNQQ6ra8A2ucC26uFX/kquRBtJu1yEyWnVSmtr07b5hyRoJRpzUeINLnyqz4/MAw==",
-              "dev": true,
-              "requires": {
-                "fs-extra": "^9.1.0"
-              }
-            },
-            "@types/mocha": {
-              "version": "9.1.1",
-              "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-              "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-              "dev": true
-            },
-            "cbor": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-              "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-              "dev": true,
-              "requires": {
-                "bignumber.js": "^9.0.1",
-                "nofilter": "^1.0.4"
-              }
-            },
-            "ethers": {
-              "version": "5.7.2",
-              "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-              "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "@ethersproject/abi": "5.7.0",
-                "@ethersproject/abstract-provider": "5.7.0",
-                "@ethersproject/abstract-signer": "5.7.0",
-                "@ethersproject/address": "5.7.0",
-                "@ethersproject/base64": "5.7.0",
-                "@ethersproject/basex": "5.7.0",
-                "@ethersproject/bignumber": "5.7.0",
-                "@ethersproject/bytes": "5.7.0",
-                "@ethersproject/constants": "5.7.0",
-                "@ethersproject/contracts": "5.7.0",
-                "@ethersproject/hash": "5.7.0",
-                "@ethersproject/hdnode": "5.7.0",
-                "@ethersproject/json-wallets": "5.7.0",
-                "@ethersproject/keccak256": "5.7.0",
-                "@ethersproject/logger": "5.7.0",
-                "@ethersproject/networks": "5.7.1",
-                "@ethersproject/pbkdf2": "5.7.0",
-                "@ethersproject/properties": "5.7.0",
-                "@ethersproject/providers": "5.7.2",
-                "@ethersproject/random": "5.7.0",
-                "@ethersproject/rlp": "5.7.0",
-                "@ethersproject/sha2": "5.7.0",
-                "@ethersproject/signing-key": "5.7.0",
-                "@ethersproject/solidity": "5.7.0",
-                "@ethersproject/strings": "5.7.0",
-                "@ethersproject/transactions": "5.7.0",
-                "@ethersproject/units": "5.7.0",
-                "@ethersproject/wallet": "5.7.0",
-                "@ethersproject/web": "5.7.1",
-                "@ethersproject/wordlists": "5.7.0"
-              }
-            },
-            "hardhat-deploy-ethers": {
-              "version": "0.3.0-beta.13",
-              "resolved": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz",
-              "integrity": "sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==",
-              "dev": true,
-              "requires": {}
-            },
-            "jsonfile": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-              "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.6"
-              }
-            },
-            "semver": {
-              "version": "6.3.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-              "dev": true
-            },
-            "typechain": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/typechain/-/typechain-5.2.0.tgz",
-              "integrity": "sha512-0INirvQ+P+MwJOeMct+WLkUE4zov06QxC96D+i3uGFEHoiSkZN70MKDQsaj8zkL86wQwByJReI2e7fOUwECFuw==",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "@types/prettier": "^2.1.1",
-                "command-line-args": "^4.0.7",
-                "debug": "^4.1.1",
-                "fs-extra": "^7.0.0",
-                "glob": "^7.1.6",
-                "js-sha3": "^0.8.0",
-                "lodash": "^4.17.15",
-                "mkdirp": "^1.0.4",
-                "prettier": "^2.1.2",
-                "ts-essentials": "^7.0.1"
-              },
-              "dependencies": {
-                "fs-extra": {
-                  "version": "7.0.1",
-                  "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-                  "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-                  "dev": true,
-                  "peer": true,
-                  "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "jsonfile": "^4.0.0",
-                    "universalify": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "typescript": {
-              "version": "4.9.5",
-              "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-              "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-              "dev": true
-            },
-            "universalify": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-              "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-              "dev": true
-            }
-          }
-        },
-        "@ethersproject/contracts": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-          "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@ethersproject/abi": "^5.7.0",
-            "@ethersproject/abstract-provider": "^5.7.0",
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0"
-          }
-        },
-        "@ethersproject/hdnode": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-          "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/basex": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/pbkdf2": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0",
-            "@ethersproject/signing-key": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "@ethersproject/wordlists": "^5.7.0"
-          }
-        },
-        "@ethersproject/json-wallets": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-          "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hdnode": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/pbkdf2": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/random": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "aes-js": "3.0.0",
-            "scrypt-js": "3.0.1"
-          },
-          "dependencies": {
-            "aes-js": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-              "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-              "dev": true,
-              "peer": true
-            }
-          }
-        },
-        "@ethersproject/pbkdf2": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-          "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0"
-          }
-        },
-        "@ethersproject/solidity": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-          "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
-        "@ethersproject/units": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-          "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/wallet": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-          "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.7.0",
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hash": "^5.7.0",
-            "@ethersproject/hdnode": "^5.7.0",
-            "@ethersproject/json-wallets": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/random": "^5.7.0",
-            "@ethersproject/signing-key": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "@ethersproject/wordlists": "^5.7.0"
-          }
-        },
-        "@ethersproject/wordlists": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-          "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hash": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
         "@noble/hashes": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
@@ -22791,16 +22402,6 @@
             "fs-extra": "^9.1.0"
           }
         },
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        },
         "cliui": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -22812,59 +22413,11 @@
             "wrap-ansi": "^7.0.0"
           }
         },
-        "command-line-args": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-          "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "find-replace": "^1.0.3",
-            "typical": "^2.6.1"
-          }
-        },
         "commander": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
           "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
           "dev": true
-        },
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "dev": true,
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-          "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          }
         },
         "ethers": {
           "version": "6.9.2",
@@ -22898,34 +22451,12 @@
             }
           }
         },
-        "find-replace": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-          "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "array-back": "^1.0.4",
-            "test-value": "^2.1.0"
-          },
-          "dependencies": {
-            "array-back": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-              "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "typical": "^2.6.0"
-              }
-            }
-          }
-        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
           "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
+          "peer": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -22938,30 +22469,11 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
           "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
+          "peer": true,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
           }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true,
-          "peer": true
-        },
-        "nofilter": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-          "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
-          "dev": true
-        },
-        "prettier": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-          "dev": true,
-          "peer": true
         },
         "semver": {
           "version": "5.7.2",
@@ -22991,18 +22503,12 @@
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         },
-        "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
-          "dev": true,
-          "peer": true
-        },
         "universalify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
           "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "ws": {
           "version": "8.5.0",
@@ -28447,6 +27953,13 @@
           "requires": {}
         }
       }
+    },
+    "hardhat-deploy-ethers": {
+      "version": "0.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz",
+      "integrity": "sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==",
+      "dev": true,
+      "requires": {}
     },
     "hardhat-gas-reporter": {
       "version": "1.0.9",


### PR DESCRIPTION
Fixes #250 

This PR changes the `SafeOperation` type to include ALL gas parameters for signing, instead of packing them. This ensures the maximum amount of data is available to the user when signing user operations, instead of trusting gas parameters from a Dapp.

Note a subtle change in the order of the "fee per gas" fields, this was done to match the order in the `PackedUserOperation` struct, as well as the order in EIP-1559 transactions. I figured, since we are changing the signing format anyway (notice the different integer types), this wouldn't be a big deal.

Additionally, we have a new test that verifies that `safeOp` hashes are computed off-chain in the same way they are computed on-chain. This is to catch issues with field orders being slightly different in the `EncodedSafeOp` struct that we would otherwise miss. Notably, the "fee per gas" parameters are always set to the same value, and our existing test suite was not able to catch swapped order in `EncodedSafeOp` fields.