### PR TITLE
Update to `EntryPoint` Release

### DIFF
--- a/examples/safe-4337-passkeys/package.json
+++ b/examples/safe-4337-passkeys/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@web3modal/ethers": "^4.0.5",
-    "@safe-global/safe-erc4337": "^0.2.0",
+    "@safe-global/safe-erc4337": "^0.3.0",
     "ethers": "^6.11.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/modules/4337/CHANGELOG.md
+++ b/modules/4337/CHANGELOG.md
@@ -17,7 +17,7 @@ The official deployments support the EntryPoint v0.7.0 with the canonical deploy
 ## Expected addresses
 
 - `SafeModuleSetup` at `0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47`
-- `Safe4337Module` at `0x9531909b0AF228B1deBdd310B40833A18bFf1152`
+- `Safe4337Module` at `0xfaa6F2eC82BdA7C22220522869E854a3446053A5`
 
 ## Changes
 

--- a/modules/4337/CHANGELOG.md
+++ b/modules/4337/CHANGELOG.md
@@ -12,7 +12,7 @@ Solidity optimizer: enabled with 10.000.000 runs
 
 ## Supported EntryPoint
 
-TBD
+The official deployments support the EntryPoint v0.7.0 with the canonical deployment at `0x0000000071727De22E5E9d8BAf0edAc6f37da032`.
 
 ## Expected addresses
 

--- a/modules/4337/CHANGELOG.md
+++ b/modules/4337/CHANGELOG.md
@@ -16,8 +16,8 @@ The official deployments support the EntryPoint v0.7.0 with the canonical deploy
 
 ## Expected addresses
 
-- `SafeModuleSetup` at `TBD`
-- `Safe4337Module` at `TBD`
+- `SafeModuleSetup` at `0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47`
+- `Safe4337Module` at `0x9531909b0AF228B1deBdd310B40833A18bFf1152`
 
 ## Changes
 

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.23;
 
 import {HandlerContext} from "@safe-global/safe-contracts/contracts/handler/HandlerContext.sol";
 import {CompatibilityFallbackHandler} from "@safe-global/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol";
-import {IAccount} from "@account-abstraction/contracts/contracts/interfaces/IAccount.sol";
-import {PackedUserOperation} from "@account-abstraction/contracts/contracts/interfaces/PackedUserOperation.sol";
-import {_packValidationData} from "@account-abstraction/contracts/contracts/core/Helpers.sol";
-import {UserOperationLib} from "@account-abstraction/contracts/contracts/core/UserOperationLib.sol";
+import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {_packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
+import {UserOperationLib} from "@account-abstraction/contracts/core/UserOperationLib.sol";
 import {ISafe} from "./interfaces/Safe.sol";
 
 /**

--- a/modules/4337/contracts/experimental/SafeSignerLaunchpad.sol
+++ b/modules/4337/contracts/experimental/SafeSignerLaunchpad.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IAccount} from "@account-abstraction/contracts/contracts/interfaces/IAccount.sol";
-import {PackedUserOperation} from "@account-abstraction/contracts/contracts/interfaces/PackedUserOperation.sol";
-import {_packValidationData} from "@account-abstraction/contracts/contracts/core/Helpers.sol";
+import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {_packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
 import {SafeStorage} from "@safe-global/safe-contracts/contracts/libraries/SafeStorage.sol";
 import {SignatureValidatorConstants} from "./SignatureValidatorConstants.sol";
 

--- a/modules/4337/contracts/test/SafeMock.sol
+++ b/modules/4337/contracts/test/SafeMock.sol
@@ -2,10 +2,10 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity >=0.8.0;
 
-import {IAccount} from "@account-abstraction/contracts/contracts/interfaces/IAccount.sol";
-import {UserOperationLib} from "@account-abstraction/contracts/contracts/core/UserOperationLib.sol";
-import {PackedUserOperation} from "@account-abstraction/contracts/contracts/interfaces/PackedUserOperation.sol";
-import {_packValidationData} from "@account-abstraction/contracts/contracts/core/Helpers.sol";
+import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";
+import {UserOperationLib} from "@account-abstraction/contracts/core/UserOperationLib.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {_packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
 
 contract SafeMock {
     address public singleton;

--- a/modules/4337/contracts/test/TestStakedFactory.sol
+++ b/modules/4337/contracts/test/TestStakedFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IEntryPoint} from "@account-abstraction/contracts/contracts/interfaces/IEntryPoint.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 
 contract TestStakedFactory {
     address public immutable FACTORY;

--- a/modules/4337/package.json
+++ b/modules/4337/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/safe-global/safe-modules/issues"
   },
   "devDependencies": {
-    "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-24",
+    "@account-abstraction/contracts": "^0.7.0",
     "@noble/curves": "^1.3.0",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@openzeppelin/contracts": "^5.0.1",

--- a/modules/4337/package.json
+++ b/modules/4337/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-erc4337",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Safe Module for ERC-4337 support",
   "homepage": "https://github.com/safe-global/safe-modules/4337",
   "license": "GPL-3.0",

--- a/modules/4337/package.json
+++ b/modules/4337/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/safe-global/safe-modules/issues"
   },
   "devDependencies": {
-    "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-12",
+    "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-24",
     "@noble/curves": "^1.3.0",
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@openzeppelin/contracts": "^5.0.1",

--- a/modules/4337/src/deploy/entrypoint.ts
+++ b/modules/4337/src/deploy/entrypoint.ts
@@ -13,7 +13,7 @@ const deploy: DeployFunction = async ({ deployments, getNamedAccounts, network }
       contract: EntryPoint,
       args: [],
       log: true,
-      deterministicDeployment: true,
+      deterministicDeployment: '0x90d8084deab30c2a37c45e8d47f49f2f7965183cb6990a98943ef94940681de3',
     })
   } else if (!ENTRY_POINT) {
     throw new Error('DEPLOYMENT_ENTRY_POINT_ADDRESS must be set')

--- a/modules/4337/src/deploy/entrypoint.ts
+++ b/modules/4337/src/deploy/entrypoint.ts
@@ -1,4 +1,4 @@
-import EntryPoint from '@account-abstraction/contracts/artifacts/contracts/core/EntryPoint.sol/EntryPoint.json'
+import EntryPoint from '@account-abstraction/contracts/artifacts/EntryPoint.json'
 import { DeployFunction } from 'hardhat-deploy/types'
 
 const ENTRY_POINT = process.env.DEPLOYMENT_ENTRY_POINT_ADDRESS

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,7 +177,7 @@
         "@safe-global/safe-contracts": "^1.4.1"
       },
       "devDependencies": {
-        "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-24",
+        "@account-abstraction/contracts": "^0.7.0",
         "@noble/curves": "^1.3.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.1",
@@ -1058,251 +1058,13 @@
       }
     },
     "node_modules/@account-abstraction/contracts": {
-      "name": "accountabstraction",
       "version": "0.7.0",
-      "resolved": "git+ssh://git@github.com/5afe/account-abstraction.git#cfd3ff7c3ec51a450bfc65974805b52be90e5596",
+      "resolved": "https://registry.npmjs.org/@account-abstraction/contracts/-/contracts-0.7.0.tgz",
+      "integrity": "sha512-Bt/66ilu3u8I9+vFZ9fTd+cWs55fdb9J5YKfrhsrFafH1drkzwuCSL/xEot1GGyXXNJLQuXbMRztQPyelNbY1A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "@nomiclabs/hardhat-etherscan": "^2.1.6",
         "@openzeppelin/contracts": "^5.0.0",
-        "@thehubbleproject/bls": "^0.5.1",
-        "@typechain/hardhat": "^2.3.0",
-        "@types/debug": "^4.1.12",
-        "@types/mocha": "^9.0.0",
-        "debug": "^4.3.4",
-        "ethereumjs-util": "^7.1.0",
-        "ethereumjs-wallet": "^1.0.1",
-        "hardhat-deploy": "^0.11.23",
-        "hardhat-deploy-ethers": "^0.3.0-beta.11",
-        "solidity-coverage": "^0.8.4",
-        "source-map-support": "^0.5.19",
-        "table": "^6.8.0",
-        "typescript": "^4.3.5"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/@typechain/hardhat": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-2.3.1.tgz",
-      "integrity": "sha512-BQV8OKQi0KAzLXCdsPO0pZBNQQ6ra8A2ucC26uFX/kquRBtJu1yEyWnVSmtr07b5hyRoJRpzUeINLnyqz4/MAw==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "^9.1.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.0.10",
-        "lodash": "^4.17.15",
-        "typechain": "^5.1.2"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/@typechain/hardhat/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "typical": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/command-line-args": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-back": "^2.0.0",
-        "find-replace": "^1.0.3",
-        "typical": "^2.6.1"
-      },
-      "bin": {
-        "command-line-args": "bin/cli.js"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/ethereumjs-util": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-      "dev": true,
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/find-replace/node_modules/array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "typical": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/typechain": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typechain/-/typechain-5.2.0.tgz",
-      "integrity": "sha512-0INirvQ+P+MwJOeMct+WLkUE4zov06QxC96D+i3uGFEHoiSkZN70MKDQsaj8zkL86wQwByJReI2e7fOUwECFuw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/prettier": "^2.1.1",
-        "command-line-args": "^4.0.7",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.0",
-        "glob": "^7.1.6",
-        "js-sha3": "^0.8.0",
-        "lodash": "^4.17.15",
-        "mkdirp": "^1.0.4",
-        "prettier": "^2.1.2",
-        "ts-essentials": "^7.0.1"
-      },
-      "bin": {
-        "typechain": "dist/cli/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.1.0"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@account-abstraction/contracts/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
+        "@uniswap/v3-periphery": "^1.4.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -4052,47 +3814,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@nomiclabs/hardhat-etherscan": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.8.tgz",
-      "integrity": "sha512-0+rj0SsZotVOcTLyDOxnOc3Gulo8upo0rsw/h+gBPcmtj91YqYJNhdARHoBxOhhE8z+5IUQPx+Dii04lXT14PA==",
-      "deprecated": "The @nomiclabs/hardhat-etherscan package is deprecated, please use @nomicfoundation/hardhat-verify instead",
-      "dev": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.1.2",
-        "@ethersproject/address": "^5.0.2",
-        "cbor": "^5.0.2",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "node-fetch": "^2.6.0",
-        "semver": "^6.3.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.0.4"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/cbor": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-      "dev": true,
-      "dependencies": {
-        "bignumber.js": "^9.0.1",
-        "nofilter": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/nofilter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@openzeppelin/contracts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.1.tgz",
@@ -5325,280 +5046,6 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/@thehubbleproject/bls": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@thehubbleproject/bls/-/bls-0.5.1.tgz",
-      "integrity": "sha512-g5zeMZ8js/yg6MjFoC+pt0eqfCL2jC46yLY1LbKNriyqftB1tE3jpG/FMMDIW3x9/yRg/AgUb8Nluqj15tQs+A==",
-      "dev": true,
-      "dependencies": {
-        "ethers": "^5.5.3",
-        "mcl-wasm": "^1.0.0"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/@ethersproject/contracts": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "^5.7.0",
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/@ethersproject/hdnode": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/basex": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/@ethersproject/json-wallets": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/@ethersproject/pbkdf2": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/@ethersproject/solidity": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/@ethersproject/units": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/@ethersproject/wallet": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/json-wallets": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/@ethersproject/wordlists": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "dev": true
-    },
-    "node_modules/@thehubbleproject/bls/node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -6136,6 +5583,55 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
+    "node_modules/@uniswap/lib": {
+      "version": "4.0.1-alpha",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
+      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.1.tgz",
+      "integrity": "sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.1.tgz",
+      "integrity": "sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.4.tgz",
+      "integrity": "sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==",
+      "dev": true,
+      "dependencies": {
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/lib": "^4.0.1-alpha",
+        "@uniswap/v2-core": "^1.0.1",
+        "@uniswap/v3-core": "^1.0.0",
+        "base64-sol": "1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery/node_modules/@openzeppelin/contracts": {
+      "version": "3.4.2-solc-0.7",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+      "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==",
       "dev": true
     },
     "node_modules/@vitejs/plugin-react-swc": {
@@ -7058,6 +6554,7 @@
       "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.2"
       }
@@ -7435,6 +6932,12 @@
         }
       ]
     },
+    "node_modules/base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg==",
+      "dev": true
+    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -7447,15 +6950,6 @@
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -8962,6 +8456,7 @@
       "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "amdefine": ">=0.0.4"
       },
@@ -9950,67 +9445,6 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/ethereumjs-wallet": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
-      "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
-      "dev": true,
-      "dependencies": {
-        "aes-js": "^3.1.2",
-        "bs58check": "^2.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethereumjs-util": "^7.1.2",
-        "randombytes": "^2.1.0",
-        "scrypt-js": "^3.0.1",
-        "utf8": "^3.0.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/ethereumjs-wallet/node_modules/aes-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
-      "dev": true
-    },
-    "node_modules/ethereumjs-wallet/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/ethereumjs-wallet/node_modules/ethereumjs-util": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-      "dev": true,
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/ethers": {
@@ -11422,16 +10856,6 @@
         "murmur-128": "^0.2.1",
         "qs": "^6.9.4",
         "zksync-web3": "^0.14.3"
-      }
-    },
-    "node_modules/hardhat-deploy-ethers": {
-      "version": "0.3.0-beta.13",
-      "resolved": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz",
-      "integrity": "sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==",
-      "dev": true,
-      "peerDependencies": {
-        "ethers": "^5.0.0",
-        "hardhat": "^2.0.0"
       }
     },
     "node_modules/hardhat-deploy/node_modules/@ethersproject/contracts": {
@@ -13166,18 +12590,6 @@
       "resolved": "https://registry.npmjs.org/match-all/-/match-all-1.2.6.tgz",
       "integrity": "sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==",
       "dev": true
-    },
-    "node_modules/mcl-wasm": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-1.4.0.tgz",
-      "integrity": "sha512-90Tvmg2NXwnKMgTafA01PRELsYNNRb/F2bj3nzdByTLLMUmgkgL8H/oeWcjZtVVffnBJyNjDcYxY7cdOE/WoHg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^20.2.5"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -16363,40 +15775,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
-    "node_modules/test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/test-value/node_modules/array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "typical": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/test-value/node_modules/typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16922,6 +16300,7 @@
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -17841,199 +17220,13 @@
       "dev": true
     },
     "@account-abstraction/contracts": {
-      "version": "git+ssh://git@github.com/5afe/account-abstraction.git#cfd3ff7c3ec51a450bfc65974805b52be90e5596",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@account-abstraction/contracts/-/contracts-0.7.0.tgz",
+      "integrity": "sha512-Bt/66ilu3u8I9+vFZ9fTd+cWs55fdb9J5YKfrhsrFafH1drkzwuCSL/xEot1GGyXXNJLQuXbMRztQPyelNbY1A==",
       "dev": true,
-      "from": "@account-abstraction/contracts@github:5afe/account-abstraction#prerelease/2024-02-24",
       "requires": {
-        "@nomiclabs/hardhat-etherscan": "^2.1.6",
         "@openzeppelin/contracts": "^5.0.0",
-        "@thehubbleproject/bls": "^0.5.1",
-        "@typechain/hardhat": "^2.3.0",
-        "@types/debug": "^4.1.12",
-        "@types/mocha": "^9.0.0",
-        "debug": "^4.3.4",
-        "ethereumjs-util": "^7.1.0",
-        "ethereumjs-wallet": "^1.0.1",
-        "hardhat-deploy": "^0.11.23",
-        "hardhat-deploy-ethers": "^0.3.0-beta.11",
-        "solidity-coverage": "^0.8.4",
-        "source-map-support": "^0.5.19",
-        "table": "^6.8.0",
-        "typescript": "^4.3.5"
-      },
-      "dependencies": {
-        "@typechain/hardhat": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-2.3.1.tgz",
-          "integrity": "sha512-BQV8OKQi0KAzLXCdsPO0pZBNQQ6ra8A2ucC26uFX/kquRBtJu1yEyWnVSmtr07b5hyRoJRpzUeINLnyqz4/MAw==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^9.1.0"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "9.1.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-              "dev": true,
-              "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            }
-          }
-        },
-        "@types/mocha": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-          "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-          "dev": true
-        },
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        },
-        "command-line-args": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-          "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "find-replace": "^1.0.3",
-            "typical": "^2.6.1"
-          }
-        },
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "dev": true,
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-          "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
-          }
-        },
-        "find-replace": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-          "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "array-back": "^1.0.4",
-            "test-value": "^2.1.0"
-          },
-          "dependencies": {
-            "array-back": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-              "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "typical": "^2.6.0"
-              }
-            }
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true,
-          "peer": true
-        },
-        "prettier": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-          "dev": true,
-          "peer": true
-        },
-        "typechain": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/typechain/-/typechain-5.2.0.tgz",
-          "integrity": "sha512-0INirvQ+P+MwJOeMct+WLkUE4zov06QxC96D+i3uGFEHoiSkZN70MKDQsaj8zkL86wQwByJReI2e7fOUwECFuw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@types/prettier": "^2.1.1",
-            "command-line-args": "^4.0.7",
-            "debug": "^4.1.1",
-            "fs-extra": "^7.0.0",
-            "glob": "^7.1.6",
-            "js-sha3": "^0.8.0",
-            "lodash": "^4.17.15",
-            "mkdirp": "^1.0.4",
-            "prettier": "^2.1.2",
-            "ts-essentials": "^7.0.1"
-          }
-        },
-        "typescript": {
-          "version": "4.9.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-          "dev": true
-        },
-        "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
-          "dev": true,
-          "peer": true
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
-        }
+        "@uniswap/v3-periphery": "^1.4.3"
       }
     },
     "@adraffy/ens-normalize": {
@@ -19898,39 +19091,6 @@
       "dev": true,
       "optional": true
     },
-    "@nomiclabs/hardhat-etherscan": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.8.tgz",
-      "integrity": "sha512-0+rj0SsZotVOcTLyDOxnOc3Gulo8upo0rsw/h+gBPcmtj91YqYJNhdARHoBxOhhE8z+5IUQPx+Dii04lXT14PA==",
-      "dev": true,
-      "requires": {
-        "@ethersproject/abi": "^5.1.2",
-        "@ethersproject/address": "^5.0.2",
-        "cbor": "^5.0.2",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "node-fetch": "^2.6.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "cbor": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-          "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-          "dev": true,
-          "requires": {
-            "bignumber.js": "^9.0.1",
-            "nofilter": "^1.0.4"
-          }
-        },
-        "nofilter": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-          "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
-          "dev": true
-        }
-      }
-    },
     "@openzeppelin/contracts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.1.tgz",
@@ -20664,7 +19824,7 @@
     "@safe-global/safe-erc4337": {
       "version": "file:modules/4337",
       "requires": {
-        "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-24",
+        "@account-abstraction/contracts": "^0.7.0",
         "@noble/curves": "^1.3.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.1",
@@ -21297,192 +20457,6 @@
         "defer-to-connect": "^2.0.1"
       }
     },
-    "@thehubbleproject/bls": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@thehubbleproject/bls/-/bls-0.5.1.tgz",
-      "integrity": "sha512-g5zeMZ8js/yg6MjFoC+pt0eqfCL2jC46yLY1LbKNriyqftB1tE3jpG/FMMDIW3x9/yRg/AgUb8Nluqj15tQs+A==",
-      "dev": true,
-      "requires": {
-        "ethers": "^5.5.3",
-        "mcl-wasm": "^1.0.0"
-      },
-      "dependencies": {
-        "@ethersproject/contracts": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-          "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abi": "^5.7.0",
-            "@ethersproject/abstract-provider": "^5.7.0",
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0"
-          }
-        },
-        "@ethersproject/hdnode": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-          "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/basex": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/pbkdf2": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0",
-            "@ethersproject/signing-key": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "@ethersproject/wordlists": "^5.7.0"
-          }
-        },
-        "@ethersproject/json-wallets": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-          "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hdnode": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/pbkdf2": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/random": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "aes-js": "3.0.0",
-            "scrypt-js": "3.0.1"
-          }
-        },
-        "@ethersproject/pbkdf2": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-          "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0"
-          }
-        },
-        "@ethersproject/solidity": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-          "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
-        "@ethersproject/units": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-          "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/wallet": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-          "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.7.0",
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hash": "^5.7.0",
-            "@ethersproject/hdnode": "^5.7.0",
-            "@ethersproject/json-wallets": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/random": "^5.7.0",
-            "@ethersproject/signing-key": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "@ethersproject/wordlists": "^5.7.0"
-          }
-        },
-        "@ethersproject/wordlists": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-          "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hash": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
-        "aes-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-          "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-          "dev": true
-        },
-        "ethers": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-          "dev": true,
-          "requires": {
-            "@ethersproject/abi": "5.7.0",
-            "@ethersproject/abstract-provider": "5.7.0",
-            "@ethersproject/abstract-signer": "5.7.0",
-            "@ethersproject/address": "5.7.0",
-            "@ethersproject/base64": "5.7.0",
-            "@ethersproject/basex": "5.7.0",
-            "@ethersproject/bignumber": "5.7.0",
-            "@ethersproject/bytes": "5.7.0",
-            "@ethersproject/constants": "5.7.0",
-            "@ethersproject/contracts": "5.7.0",
-            "@ethersproject/hash": "5.7.0",
-            "@ethersproject/hdnode": "5.7.0",
-            "@ethersproject/json-wallets": "5.7.0",
-            "@ethersproject/keccak256": "5.7.0",
-            "@ethersproject/logger": "5.7.0",
-            "@ethersproject/networks": "5.7.1",
-            "@ethersproject/pbkdf2": "5.7.0",
-            "@ethersproject/properties": "5.7.0",
-            "@ethersproject/providers": "5.7.2",
-            "@ethersproject/random": "5.7.0",
-            "@ethersproject/rlp": "5.7.0",
-            "@ethersproject/sha2": "5.7.0",
-            "@ethersproject/signing-key": "5.7.0",
-            "@ethersproject/solidity": "5.7.0",
-            "@ethersproject/strings": "5.7.0",
-            "@ethersproject/transactions": "5.7.0",
-            "@ethersproject/units": "5.7.0",
-            "@ethersproject/wallet": "5.7.0",
-            "@ethersproject/web": "5.7.1",
-            "@ethersproject/wordlists": "5.7.0"
-          }
-        }
-      }
-    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -21905,6 +20879,45 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "@uniswap/lib": {
+      "version": "4.0.1-alpha",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
+      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==",
+      "dev": true
+    },
+    "@uniswap/v2-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.1.tgz",
+      "integrity": "sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==",
+      "dev": true
+    },
+    "@uniswap/v3-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.1.tgz",
+      "integrity": "sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==",
+      "dev": true
+    },
+    "@uniswap/v3-periphery": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.4.tgz",
+      "integrity": "sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==",
+      "dev": true,
+      "requires": {
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/lib": "^4.0.1-alpha",
+        "@uniswap/v2-core": "^1.0.1",
+        "@uniswap/v3-core": "^1.0.0",
+        "base64-sol": "1.0.1"
+      },
+      "dependencies": {
+        "@openzeppelin/contracts": {
+          "version": "3.4.2-solc-0.7",
+          "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+          "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==",
+          "dev": true
+        }
+      }
     },
     "@vitejs/plugin-react-swc": {
       "version": "3.6.0",
@@ -22692,7 +21705,8 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -22973,6 +21987,12 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg==",
+      "dev": true
+    },
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -22982,12 +22002,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
       "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
-      "dev": true
-    },
-    "bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "dev": true
     },
     "binary-extensions": {
@@ -24160,6 +23174,7 @@
           "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
           "dev": true,
           "optional": true,
+          "peer": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -24886,66 +23901,6 @@
             "scrypt-js": "^3.0.0",
             "secp256k1": "^4.0.1",
             "setimmediate": "^1.0.5"
-          }
-        }
-      }
-    },
-    "ethereumjs-wallet": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz",
-      "integrity": "sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==",
-      "dev": true,
-      "requires": {
-        "aes-js": "^3.1.2",
-        "bs58check": "^2.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethereumjs-util": "^7.1.2",
-        "randombytes": "^2.1.0",
-        "scrypt-js": "^3.0.1",
-        "utf8": "^3.0.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "aes-js": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-          "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
-          "dev": true
-        },
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "dev": true,
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-          "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^5.1.0",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
-            "rlp": "^2.2.4"
           }
         }
       }
@@ -26182,13 +25137,6 @@
         }
       }
     },
-    "hardhat-deploy-ethers": {
-      "version": "0.3.0-beta.13",
-      "resolved": "https://registry.npmjs.org/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.13.tgz",
-      "integrity": "sha512-PdWVcKB9coqWV1L7JTpfXRCI91Cgwsm7KLmBcwZ8f0COSm1xtABHZTyz3fvF6p42cTnz1VM0QnfDvMFlIRkSNw==",
-      "dev": true,
-      "requires": {}
-    },
     "hardhat-gas-reporter": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.10.tgz",
@@ -27179,15 +26127,6 @@
       "resolved": "https://registry.npmjs.org/match-all/-/match-all-1.2.6.tgz",
       "integrity": "sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==",
       "dev": true
-    },
-    "mcl-wasm": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-1.4.0.tgz",
-      "integrity": "sha512-90Tvmg2NXwnKMgTafA01PRELsYNNRb/F2bj3nzdByTLLMUmgkgL8H/oeWcjZtVVffnBJyNjDcYxY7cdOE/WoHg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^20.2.5"
-      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -29625,36 +28564,6 @@
         }
       }
     },
-    "test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        },
-        "typical": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -30041,7 +28950,8 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "uint8arrays": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,7 +177,7 @@
         "@safe-global/safe-contracts": "^1.4.1"
       },
       "devDependencies": {
-        "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-12",
+        "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-24",
         "@noble/curves": "^1.3.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.1",
@@ -1059,8 +1059,8 @@
     },
     "node_modules/@account-abstraction/contracts": {
       "name": "accountabstraction",
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/5afe/account-abstraction.git#cb4d0bd5bda5b189c9e228261ac91fe9a83a3542",
+      "version": "0.7.0",
+      "resolved": "git+ssh://git@github.com/5afe/account-abstraction.git#cfd3ff7c3ec51a450bfc65974805b52be90e5596",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -17841,9 +17841,9 @@
       "dev": true
     },
     "@account-abstraction/contracts": {
-      "version": "git+ssh://git@github.com/5afe/account-abstraction.git#cb4d0bd5bda5b189c9e228261ac91fe9a83a3542",
+      "version": "git+ssh://git@github.com/5afe/account-abstraction.git#cfd3ff7c3ec51a450bfc65974805b52be90e5596",
       "dev": true,
-      "from": "@account-abstraction/contracts@github:5afe/account-abstraction#prerelease/2024-02-12",
+      "from": "@account-abstraction/contracts@github:5afe/account-abstraction#prerelease/2024-02-24",
       "requires": {
         "@nomiclabs/hardhat-etherscan": "^2.1.6",
         "@openzeppelin/contracts": "^5.0.0",
@@ -20664,7 +20664,7 @@
     "@safe-global/safe-erc4337": {
       "version": "file:modules/4337",
       "requires": {
-        "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-12",
+        "@account-abstraction/contracts": "github:5afe/account-abstraction#prerelease/2024-02-24",
         "@noble/curves": "^1.3.0",
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     "examples/safe-4337-passkeys": {
       "version": "0.0.0",
       "dependencies": {
-        "@safe-global/safe-erc4337": "^0.2.0",
+        "@safe-global/safe-erc4337": "^0.3.0",
         "@web3modal/ethers": "^4.0.5",
         "ethers": "^6.11.1",
         "react": "^18.2.0",
@@ -171,7 +171,7 @@
     },
     "modules/4337": {
       "name": "@safe-global/safe-erc4337",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@safe-global/safe-contracts": "^1.4.1"
@@ -28615,7 +28615,7 @@
     "safe-4337-passkeys": {
       "version": "file:examples/safe-4337-passkeys",
       "requires": {
-        "@safe-global/safe-erc4337": "^0.2.0",
+        "@safe-global/safe-erc4337": "^0.3.0",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.19",
         "@vitejs/plugin-react-swc": "^3.6.0",


### PR DESCRIPTION
With the `EntryPoint` v0.7 release right around the corner, this PR updates the branch to use the contract version that was deployed.

We manage to deploy the `EntryPoint` to the exact same address, so are definitely using the correct code :)

```bash
$ npx hardhat deploy --network hardhat | rg '"EntryPoint"'
deploying "EntryPoint" (tx: 0x1ca5c698c8f3416559c59a95356a344285fa17e674072ed9d63b0f79ba224963)...: deployed at 0x0000000071727De22E5E9d8BAf0edAc6f37da032 with 3650209 gas
```