### PR TITLE
Fix E2E Tests For ERC-4337 v0.7 Bundler

### DIFF
--- a/modules/4337/docker/bundler/Dockerfile
+++ b/modules/4337/docker/bundler/Dockerfile
@@ -1,9 +1,11 @@
 FROM docker.io/library/node:18
 
-ARG TAG=v0.6.1
+# v0.7.0
+ARG TAG=26e4f4c
 RUN git clone https://github.com/eth-infinitism/bundler /src/bundler
 WORKDIR /src/bundler
 RUN git checkout ${TAG}
+RUN git submodule init && git submodule update
 
 RUN yarn && yarn preprocess
 ENTRYPOINT ["yarn", "bundler"]

--- a/modules/4337/scripts/runOp.ts
+++ b/modules/4337/scripts/runOp.ts
@@ -1,7 +1,7 @@
 import { Result } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { UserOperation, getRequiredPrefund, getSupportedEntryPoints } from '../src/utils/userOp'
+import { getRequiredPrefund, getSupportedEntryPoints } from '../src/utils/userOp'
 import { chainId } from '../test/utils/encoding'
 import { getSafe4337Module } from '../test/utils/setup'
 import { GlobalConfig, MultiProvider4337, Safe4337 } from '../src/utils/safe'
@@ -108,6 +108,7 @@ const runOp = async () => {
     ]),
   )
 
+  const packedUserOp = await operation.packedUserOperation()
   console.log(
     'validateUserOp',
     await ethers.provider.send('eth_call', [
@@ -116,18 +117,18 @@ const runOp = async () => {
         to: safe.address,
         data: buildData('validateUserOp((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes),bytes32,uint256)', [
           [
-            userOp.sender,
-            userOp.nonce,
-            userOp.initCode,
-            userOp.callData,
-            userOp.accountGasLimits,
-            userOp.preVerificationGas,
-            userOp.gasFees,
-            userOp.paymasterAndData,
-            userOp.signature,
+            packedUserOp.sender,
+            packedUserOp.nonce,
+            packedUserOp.initCode,
+            packedUserOp.callData,
+            packedUserOp.accountGasLimits,
+            packedUserOp.preVerificationGas,
+            packedUserOp.gasFees,
+            packedUserOp.paymasterAndData,
+            packedUserOp.signature,
           ],
           '0x0000000000000000000000000000000000000000000000000000000000000000',
-          getRequiredPrefund(userOp),
+          getRequiredPrefund(packedUserOp),
         ]),
       },
       'latest',

--- a/modules/4337/test/e2e/4337NestedSafe.spec.ts
+++ b/modules/4337/test/e2e/4337NestedSafe.spec.ts
@@ -12,7 +12,12 @@ import {
   preimageSafeTransactionHash,
   signHash,
 } from '../../src/utils/execution'
-import { buildUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp, SafeUserOperation } from '../../src/utils/userOp'
+import {
+  buildRpcUserOperationFromSafeUserOperation,
+  buildSafeUserOpTransaction,
+  signSafeOp,
+  SafeUserOperation,
+} from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
 import { Safe4337 } from '../../src/utils/safe'
 import { BUNDLER_MNEMONIC, bundlerRpc, prepareAccounts, waitForUserOp } from '../utils/e2e'
@@ -403,7 +408,7 @@ describe('E2E - Nested Safes With An Execution Initiated by a Leaf 4337 Safe', (
     const executorSigner = executor.owners[0].value as Signer
     const safeOp = await buildNestedSafeOp(safeTransaction, tree.root, executionPath, await entryPoint.getAddress())
     const signature = buildSignatureBytes([await signSafeOp(executorSigner, await validator.getAddress(), safeOp, await chainId())])
-    const userOp = buildUserOperationFromSafeUserOperation({
+    const userOp = await buildRpcUserOperationFromSafeUserOperation({
       safeOp,
       signature,
     })

--- a/modules/4337/test/e2e/LocalBundler.spec.ts
+++ b/modules/4337/test/e2e/LocalBundler.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { deployments, ethers, network } from 'hardhat'
 import { buildSignatureBytes } from '../../src/utils/execution'
-import { buildUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp } from '../../src/utils/userOp'
+import { buildRpcUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp } from '../../src/utils/userOp'
 import { chainId, timestamp } from '../utils/encoding'
 import { Safe4337 } from '../../src/utils/safe'
 import { bundlerRpc, prepareAccounts, waitForUserOp } from '../utils/e2e'
@@ -71,7 +71,7 @@ describe('E2E - Local Bundler', () => {
       },
     )
     const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
-    const userOp = buildUserOperationFromSafeUserOperation({
+    const userOp = await buildRpcUserOperationFromSafeUserOperation({
       safeOp,
       signature,
     })
@@ -103,7 +103,7 @@ describe('E2E - Local Bundler', () => {
       await entryPoint.getAddress(),
     )
     const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
-    const userOp = buildUserOperationFromSafeUserOperation({
+    const userOp = await buildRpcUserOperationFromSafeUserOperation({
       safeOp,
       signature,
     })

--- a/modules/4337/test/e2e/SingletonSigners.spec.ts
+++ b/modules/4337/test/e2e/SingletonSigners.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai'
 import { deployments, ethers, network } from 'hardhat'
 import { buildSignatureBytes } from '../../src/utils/execution'
-import { buildUserOperationFromSafeUserOperation, buildSafeUserOpTransaction } from '../../src/utils/userOp'
+import {
+  buildPackedUserOperationFromSafeUserOperation,
+  buildRpcUserOperationFromSafeUserOperation,
+  buildSafeUserOpTransaction,
+} from '../../src/utils/userOp'
 import { bundlerRpc, encodeMultiSendTransactions, prepareAccounts, waitForUserOp } from '../utils/e2e'
 
 describe('E2E - Singleton Signers', () => {
@@ -105,7 +109,7 @@ describe('E2E - Singleton Signers', () => {
       { initCode },
     )
     const opHash = await validator.getOperationHash(
-      buildUserOperationFromSafeUserOperation({
+      buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature: '0x',
       }),
@@ -117,7 +121,7 @@ describe('E2E - Singleton Signers', () => {
         dynamic: true,
       })),
     )
-    const userOp = buildUserOperationFromSafeUserOperation({
+    const userOp = await buildRpcUserOperationFromSafeUserOperation({
       safeOp,
       signature,
     })

--- a/modules/4337/test/e2e/WebAuthnSingletonSigner.spec.ts
+++ b/modules/4337/test/e2e/WebAuthnSingletonSigner.spec.ts
@@ -8,7 +8,11 @@ import {
   extractPublicKey,
   extractSignature,
 } from '../utils/webauthn'
-import { buildSafeUserOpTransaction, buildUserOperationFromSafeUserOperation } from '../../src/utils/userOp'
+import {
+  buildSafeUserOpTransaction,
+  buildPackedUserOperationFromSafeUserOperation,
+  buildRpcUserOperationFromSafeUserOperation,
+} from '../../src/utils/userOp'
 import { buildSignatureBytes } from '../../src/utils/execution'
 
 describe('E2E - WebAuthn Singleton Signers', () => {
@@ -139,7 +143,7 @@ describe('E2E - WebAuthn Singleton Signers', () => {
       },
     )
     const opHash = await module.getOperationHash(
-      buildUserOperationFromSafeUserOperation({
+      buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature: '0x',
       }),
@@ -166,7 +170,7 @@ describe('E2E - WebAuthn Singleton Signers', () => {
         dynamic: true,
       },
     ])
-    const userOp = buildUserOperationFromSafeUserOperation({
+    const userOp = await buildRpcUserOperationFromSafeUserOperation({
       safeOp,
       signature,
     })

--- a/modules/4337/test/erc4337/ERC4337ModuleExisting.spec.ts
+++ b/modules/4337/test/erc4337/ERC4337ModuleExisting.spec.ts
@@ -2,7 +2,11 @@ import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 import { getTestSafe, getSafe4337Module, getEntryPoint } from '../utils/setup'
 import { buildSignatureBytes, signHash, logGas } from '../../src/utils/execution'
-import { calculateSafeOperationHash, buildUserOperationFromSafeUserOperation, buildSafeUserOpTransaction } from '../../src/utils/userOp'
+import {
+  calculateSafeOperationHash,
+  buildPackedUserOperationFromSafeUserOperation,
+  buildSafeUserOpTransaction,
+} from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
 
 describe('Safe4337Module - Existing Safe', () => {
@@ -38,7 +42,7 @@ describe('Safe4337Module - Existing Safe', () => {
         await entryPoint.getAddress(),
       )
       const signature = buildSignatureBytes([await signHash(user1, ethers.keccak256('0xbaddad42'))])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       await expect(entryPoint.handleOps([userOp], user1.address))
         .to.be.revertedWithCustomError(entryPoint, 'FailedOp')
         .withArgs(0, 'AA24 signature error')
@@ -64,7 +68,7 @@ describe('Safe4337Module - Existing Safe', () => {
       )
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       await logGas('Execute UserOp without a prefund payment', entryPoint.handleOps([userOp], relayer))
       expect(await ethers.provider.getBalance(await safe.getAddress())).to.be.eq(ethers.parseEther('0'))
     })
@@ -85,7 +89,7 @@ describe('Safe4337Module - Existing Safe', () => {
       )
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       await entryPoint.handleOps([userOp], user1.address)
       expect(await ethers.provider.getBalance(receiver)).to.be.eq(ethers.parseEther('0.5'))
       await expect(entryPoint.handleOps([userOp], user1.address))
@@ -111,7 +115,7 @@ describe('Safe4337Module - Existing Safe', () => {
       )
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       await logGas('Execute UserOp with fee payment', entryPoint.handleOps([userOp], feeBeneficiary))
 
       // checking that the fee was paid
@@ -135,7 +139,7 @@ describe('Safe4337Module - Existing Safe', () => {
       )
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       const userOpHash = await entryPoint.getUserOpHash(userOp)
       const expectedReturnData = validator.interface.encodeErrorResult('ExecutionFailed()', [])
 
@@ -164,7 +168,7 @@ describe('Safe4337Module - Existing Safe', () => {
       )
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       await logGas('Execute UserOp without fee payment and bubble up error string', entryPoint.handleOps([userOp], relayer))
       expect(await ethers.provider.getBalance(await safe.getAddress())).to.be.eq(ethers.parseEther('0.5'))
     })
@@ -188,7 +192,7 @@ describe('Safe4337Module - Existing Safe', () => {
       )
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
 
       const expectedRevertReason = validator.interface.encodeErrorResult('Error(string)', ['You called a function that always reverts'])
 

--- a/modules/4337/test/erc4337/ERC4337ModuleNew.spec.ts
+++ b/modules/4337/test/erc4337/ERC4337ModuleNew.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 import { getSafe4337Module, getEntryPoint, getFactory, getSafeModuleSetup, getSafeL2Singleton } from '../utils/setup'
 import { buildSignatureBytes, logGas } from '../../src/utils/execution'
-import { buildUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp } from '../../src/utils/userOp'
+import { buildPackedUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp } from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
 import { Safe4337 } from '../../src/utils/safe'
 
@@ -58,7 +58,7 @@ describe('Safe4337Module - Newly deployed safe', () => {
         },
       )
       const signature = buildSignatureBytes([await signSafeOp(user1, user1.address, safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -90,7 +90,7 @@ describe('Safe4337Module - Newly deployed safe', () => {
       )
 
       const signature = buildSignatureBytes([await signSafeOp(user1, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -114,7 +114,7 @@ describe('Safe4337Module - Newly deployed safe', () => {
         await entryPoint.getAddress(),
       )
       const signature = buildSignatureBytes([await signSafeOp(user1, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -143,7 +143,7 @@ describe('Safe4337Module - Newly deployed safe', () => {
         },
       )
       const signature = buildSignatureBytes([await signSafeOp(user1, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -175,7 +175,7 @@ describe('Safe4337Module - Newly deployed safe', () => {
         },
       )
       const signature = buildSignatureBytes([await signSafeOp(user1, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -207,7 +207,7 @@ describe('Safe4337Module - Newly deployed safe', () => {
         },
       )
       const signature = buildSignatureBytes([await signSafeOp(user1, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -237,7 +237,7 @@ describe('Safe4337Module - Newly deployed safe', () => {
         },
       )
       const signature = buildSignatureBytes([await signSafeOp(user1, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })

--- a/modules/4337/test/erc4337/ERC4337WebAuthn.spec.ts
+++ b/modules/4337/test/erc4337/ERC4337WebAuthn.spec.ts
@@ -4,7 +4,7 @@ import { getEntryPoint } from '../utils/setup'
 import { buildSignatureBytes, logGas } from '../../src/utils/execution'
 import {
   buildSafeUserOpTransaction,
-  buildUserOperationFromSafeUserOperation,
+  buildPackedUserOperationFromSafeUserOperation,
   calculateSafeOperationHash,
   packGasParameters,
 } from '../../src/utils/userOp'
@@ -299,7 +299,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
       await user.sendTransaction({ to: safe.address, value: ethers.parseEther('1') }).then((tx) => tx.wait())
       expect(await ethers.provider.getBalance(safe.address)).to.equal(ethers.parseEther('1'))
 
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       await logGas('WebAuthn signer Safe operation', entryPoint.handleOps([userOp], user.address))
 
       expect(await ethers.provider.getBalance(safe.address)).to.be.lessThanOrEqual(ethers.parseEther('0.5'))

--- a/modules/4337/test/erc4337/ReferenceEntryPoint.spec.ts
+++ b/modules/4337/test/erc4337/ReferenceEntryPoint.spec.ts
@@ -6,7 +6,7 @@ import { getEntryPoint, getFactory, getSafeModuleSetup } from '../utils/setup'
 import { buildSignatureBytes, logGas } from '../../src/utils/execution'
 import {
   buildSafeUserOpTransaction,
-  buildUserOperationFromSafeUserOperation,
+  buildPackedUserOperationFromSafeUserOperation,
   calculateSafeOperationData,
   signSafeOp,
 } from '../../src/utils/userOp'
@@ -71,7 +71,7 @@ describe('Safe4337Module - Reference EntryPoint', () => {
           },
         )
         const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
-        return buildUserOperationFromSafeUserOperation({
+        return buildPackedUserOperationFromSafeUserOperation({
           safeOp,
           signature,
         })
@@ -120,7 +120,7 @@ describe('Safe4337Module - Reference EntryPoint', () => {
           },
         )
         const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
-        return buildUserOperationFromSafeUserOperation({
+        return buildPackedUserOperationFromSafeUserOperation({
           safeOp,
           signature,
         })
@@ -186,7 +186,7 @@ describe('Safe4337Module - Reference EntryPoint', () => {
         dynamic: true,
       },
     ])
-    const userOp = buildUserOperationFromSafeUserOperation({
+    const userOp = buildPackedUserOperationFromSafeUserOperation({
       safeOp,
       signature,
     })

--- a/modules/4337/test/erc4337/Safe4337Mock.spec.ts
+++ b/modules/4337/test/erc4337/Safe4337Mock.spec.ts
@@ -5,7 +5,7 @@ import { buildSignatureBytes, signHash, logGas } from '../../src/utils/execution
 import {
   buildSafeUserOp,
   buildSafeUserOpTransaction,
-  buildUserOperationFromSafeUserOperation,
+  buildPackedUserOperationFromSafeUserOperation,
   calculateSafeOperationHash,
 } from '../../src/utils/userOp'
 import { chainId, timestamp } from '../utils/encoding'
@@ -48,7 +48,7 @@ describe('Safe4337Mock', () => {
       )
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       await logGas('Execute UserOp without fee payment', entryPoint.handleOps([userOp], user1.address))
       expect(await ethers.provider.getBalance(await safe.getAddress())).to.be.eq(ethers.parseEther('0.5'))
     })
@@ -71,7 +71,7 @@ describe('Safe4337Mock', () => {
       )
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user1, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({ safeOp, signature })
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
       await logGas('Execute UserOp with fee payment', entryPoint.handleOps([userOp], feeBeneficiary))
 
       // checking that the fee was paid
@@ -111,7 +111,7 @@ describe('Safe4337Mock', () => {
         validAfter,
         validUntil,
       })
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature: '0x',
       })

--- a/modules/4337/test/erc4337/Safe4337Module.spec.ts
+++ b/modules/4337/test/erc4337/Safe4337Module.spec.ts
@@ -7,7 +7,7 @@ import {
   GasParameters,
   buildSafeUserOp,
   buildSafeUserOpTransaction,
-  buildUserOperationFromSafeUserOperation,
+  buildPackedUserOperationFromSafeUserOperation,
   calculateSafeOperationHash,
   packGasParameters,
   packValidationData,
@@ -160,7 +160,7 @@ describe('Safe4337Module', () => {
         validAfter,
         validUntil,
       })
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature: '0x',
       })
@@ -178,7 +178,7 @@ describe('Safe4337Module', () => {
       const safeOp = buildSafeUserOpTransaction(await safeModule.getAddress(), user.address, 0, '0x', '0', await entryPoint.getAddress())
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -207,7 +207,7 @@ describe('Safe4337Module', () => {
       })
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -224,7 +224,7 @@ describe('Safe4337Module', () => {
       const safeOp = buildSafeUserOpTransaction(await safeModule.getAddress(), user.address, 0, '0x', '0', await entryPoint.getAddress())
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -258,7 +258,7 @@ describe('Safe4337Module', () => {
 
       const safeOpHash = calculateSafeOperationHash(await validator.getAddress(), safeOp, await chainId())
       const signature = buildSignatureBytes([await signHash(user, safeOpHash)])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })

--- a/modules/4337/test/gas/Gas.spec.ts
+++ b/modules/4337/test/gas/Gas.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 import { getSafe4337Module, getEntryPoint, getFactory, getSafeModuleSetup, getSafeL2Singleton } from '../utils/setup'
 import { buildSignatureBytes, logGas } from '../../src/utils/execution'
-import { buildUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp } from '../../src/utils/userOp'
+import { buildPackedUserOperationFromSafeUserOperation, buildSafeUserOpTransaction, signSafeOp } from '../../src/utils/userOp'
 import { chainId } from '../utils/encoding'
 import { Safe4337 } from '../../src/utils/safe'
 
@@ -64,7 +64,7 @@ describe('Gas Metering', () => {
 
       const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
 
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -103,7 +103,7 @@ describe('Gas Metering', () => {
 
       const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
 
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -138,7 +138,7 @@ describe('Gas Metering', () => {
         false,
       )
       const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -177,7 +177,7 @@ describe('Gas Metering', () => {
 
       const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
 
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -209,7 +209,7 @@ describe('Gas Metering', () => {
         },
       )
       const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -249,7 +249,7 @@ describe('Gas Metering', () => {
         false,
       )
       const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })
@@ -283,7 +283,7 @@ describe('Gas Metering', () => {
         false,
       )
       const signature = buildSignatureBytes([await signSafeOp(user, await validator.getAddress(), safeOp, await chainId())])
-      const userOp = buildUserOperationFromSafeUserOperation({
+      const userOp = buildPackedUserOperationFromSafeUserOperation({
         safeOp,
         signature,
       })


### PR DESCRIPTION
Fixes #227 

This PR updates the E2E tests to work with the latest bundler for the EntryPoint contract v0.7. Note that there was a notable change in that the `PackedUserOperation` struct is only used on-chain, and the bundler RPC uses a different `UserOperation` type that is completely unpacked. This required some additional helper methods as well as some adjustments to tests to distinguish between the packed and unpacked versions of user operations.

Also, unfortunately the reference bundler repository is not tagged yet - so we are using a commit hash that corresponds to the latest version. I asked the 4337 team to create a new tag, at which point, I will update the docker file. Additionally, the latest bundler version uses submodules, so some dockerfile tweaking was required.