### PR TITLE
Formatting issue for 4337 gas metering in CI

### DIFF
--- a/examples/4337-gas-metering/.prettierignore
+++ b/examples/4337-gas-metering/.prettierignore
@@ -1,0 +1,1 @@
+tsconfig.json

--- a/examples/4337-gas-metering/tsconfig.json
+++ b/examples/4337-gas-metering/tsconfig.json
@@ -13,7 +13,7 @@
     /* Completeness */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "outDir": "./dist" /* Redirect output structure to the directory. */,
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }

--- a/examples/4337-gas-metering/tsconfig.json
+++ b/examples/4337-gas-metering/tsconfig.json
@@ -13,7 +13,7 @@
     /* Completeness */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "outDir": "./dist" /* Redirect output structure to the directory. */,
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
This PR removed the formatting issue in the `4337-gas-metering` CI.

CI failure for `safe-modules-examples` remains, and will be solved later with #270 