### PR TITLE
Using new `v0.7` for 4337 Gas Metering

### DIFF
--- a/examples/4337-gas-metering/.env.example
+++ b/examples/4337-gas-metering/.env.example
@@ -2,20 +2,20 @@
 PRIVATE_KEY = "0x..." # Add "0x" to Private Key if not already added.
 
 # Pimlico Values
-PIMLICO_CHAIN = "mumbai" # or "goerli"
-PIMLICO_CHAIN_ID = "80001"
-PIMLICO_RPC_URL = "https://rpc.ankr.com/polygon_mumbai"
+PIMLICO_CHAIN = "base-sepolia" # or "sepolia"
+PIMLICO_CHAIN_ID = "84532" # or "11155111"
+PIMLICO_RPC_URL = "https://rpc.ankr.com/base_sepolia" # or "https://rpc.ankr.com/eth_sepolia"
 PIMLICO_API_KEY = "" # https://dashboard.pimlico.io/apikeys
 PIMLICO_GAS_POLICY = "" # https://dashboard.pimlico.io/sponsorship-policies
-PIMLICO_ENTRYPOINT_ADDRESS = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+PIMLICO_ENTRYPOINT_ADDRESS = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
 PIMLICO_MULTISEND_ADDRESS = "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526" # https://github.com/safe-global/safe-deployments/blob/main/src/assets/v1.4.1/multi_send.json
-PIMLICO_ERC20_PAYMASTER_ADDRESS = "0x32aCDFeA07a614E52403d2c1feB747aa8079A353" # https://docs.pimlico.io/erc20-paymaster/reference/contracts
-PIMLICO_USDC_TOKEN_ADDRESS = "0x0FA8781a83E46826621b3BC094Ea2A0212e71B23" # Mumbai USDC Address used by Pimlico
+PIMLICO_ERC20_PAYMASTER_ADDRESS = "0x0000000000dd6dd248ab5487218e1c2d7fbb29c9" # https://docs.pimlico.io/paymaster/erc20-paymaster/contract-addresses
+PIMLICO_USDC_TOKEN_ADDRESS = "0x036CbD53842c5426634e7929541eC2318f3dCF7e" # Sepolia USDC Address used by Pimlico
 # Make sure all nonce are unique for it to deploy account when run initially.
-PIMLICO_NONCE = "1"
+PIMLICO_NONCE = "3"
 # Pimlico Token Operation Values (Based on the chain selected, these values should also change accordingly.)
-PIMLICO_ERC20_TOKEN_CONTRACT = "0x255de08fb52fde17a3aab145de8e2ffb7fd0310f"
-PIMLICO_ERC721_TOKEN_CONTRACT = "0x16bc5fba06f3f5875e915c0ba6963377eb6651e1"
+PIMLICO_ERC20_TOKEN_CONTRACT = "0x0b3ff6382bd1a8a74f23d39b4d131a08cea2502a"
+PIMLICO_ERC721_TOKEN_CONTRACT = "0xf13eca34092D27cbF91cD377eFB261704C687a05"
 
 # Alchemy Values
 ALCHEMY_CHAIN = "sepolia" # or "goerli"
@@ -23,7 +23,7 @@ ALCHEMY_CHAIN_ID = "11155111"
 ALCHEMY_RPC_URL = "https://eth-sepolia.g.alchemy.com/v2/Your_API_Key"
 ALCHEMY_API_KEY = "" # https://dashboard.alchemy.com/apps
 ALCHEMY_GAS_POLICY = "" # https://dashboard.alchemy.com/gas-manager
-ALCHEMY_ENTRYPOINT_ADDRESS = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+ALCHEMY_ENTRYPOINT_ADDRESS = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
 ALCHEMY_MULTISEND_ADDRESS = "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526" # https://github.com/safe-global/safe-deployments/blob/main/src/assets/v1.4.1/multi_send.json
 # Make sure all nonce are unique for it to deploy account when run initially.
 ALCHEMY_NONCE = "2"
@@ -37,7 +37,7 @@ GELATO_CHAIN_ID = "11155111"
 GELATO_RPC_URL = "https://rpc.ankr.com/eth_sepolia"
 GELATO_API_KEY = "" # Sponsor API Key
 GELATO_GAS_POLICY = ""
-GELATO_ENTRYPOINT_ADDRESS = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+GELATO_ENTRYPOINT_ADDRESS = "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
 GELATO_MULTISEND_ADDRESS = "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526" # https://github.com/safe-global/safe-deployments/blob/main/src/assets/v1.4.1/multi_send.json
 # Make sure all nonce are unique for it to deploy account when run initially.
 GELATO_NONCE = "3"

--- a/examples/4337-gas-metering/alchemy/alchemy.ts
+++ b/examples/4337-gas-metering/alchemy/alchemy.ts
@@ -103,7 +103,7 @@ const alchemy = new Alchemy(settings)
 
 const initCode = await getAccountInitCode({
   owner: signer.address,
-  addModuleLibAddress: chainAddresses.ADD_MODULES_LIB_ADDRESS,
+  safeModuleSetupAddress: chainAddresses.SAFE_MODULE_SETUP_ADDRESS,
   safe4337ModuleAddress: chainAddresses.SAFE_4337_MODULE_ADDRESS,
   safeProxyFactoryAddress: chainAddresses.SAFE_PROXY_FACTORY_ADDRESS,
   safeSingletonAddress: chainAddresses.SAFE_SINGLETON_ADDRESS,
@@ -117,7 +117,7 @@ console.log('\nInit Code Created.')
 const senderAddress = await getAccountAddress({
   client: publicClient,
   owner: signer.address,
-  addModuleLibAddress: chainAddresses.ADD_MODULES_LIB_ADDRESS,
+  safeModuleSetupAddress: chainAddresses.SAFE_MODULE_SETUP_ADDRESS,
   safe4337ModuleAddress: chainAddresses.SAFE_4337_MODULE_ADDRESS,
   safeProxyFactoryAddress: chainAddresses.SAFE_PROXY_FACTORY_ADDRESS,
   safeSingletonAddress: chainAddresses.SAFE_SINGLETON_ADDRESS,

--- a/examples/4337-gas-metering/gelato/gelato.ts
+++ b/examples/4337-gas-metering/gelato/gelato.ts
@@ -81,7 +81,7 @@ if (chain == 'sepolia') {
 
 const initCode = await getAccountInitCode({
   owner: signer.address,
-  addModuleLibAddress: chainAddresses.ADD_MODULES_LIB_ADDRESS,
+  safeModuleSetupAddress: chainAddresses.SAFE_MODULE_SETUP_ADDRESS,
   safe4337ModuleAddress: chainAddresses.SAFE_4337_MODULE_ADDRESS,
   safeProxyFactoryAddress: chainAddresses.SAFE_PROXY_FACTORY_ADDRESS,
   safeSingletonAddress: chainAddresses.SAFE_SINGLETON_ADDRESS,
@@ -95,7 +95,7 @@ console.log('\nInit Code Created.')
 const senderAddress = await getAccountAddress({
   client: publicClient,
   owner: signer.address,
-  addModuleLibAddress: chainAddresses.ADD_MODULES_LIB_ADDRESS,
+  safeModuleSetupAddress: chainAddresses.SAFE_MODULE_SETUP_ADDRESS,
   safe4337ModuleAddress: chainAddresses.SAFE_4337_MODULE_ADDRESS,
   safeProxyFactoryAddress: chainAddresses.SAFE_PROXY_FACTORY_ADDRESS,
   safeSingletonAddress: chainAddresses.SAFE_SINGLETON_ADDRESS,

--- a/examples/4337-gas-metering/package.json
+++ b/examples/4337-gas-metering/package.json
@@ -17,7 +17,7 @@
     "alchemy:erc721:paymaster": "tsx ./alchemy/alchemy.ts erc721 paymaster=true",
     "alchemy": "tsx ./alchemy/alchemy.ts",
     "build": "npx rimraf dist && tsc",
-    "fmt": "prettier --ignore-path .gitignore --write .",
+    "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "lint": "eslint ./alchemy && eslint ./gelato && eslint ./pimlico && eslint ./utils",
     "gelato:account:1balance": "tsx ./gelato/gelato.ts account",
@@ -55,7 +55,7 @@
     "@alchemy/aa-core": "2.3.1",
     "alchemy-sdk": "3.1.2",
     "dotenv": "16.4.4",
-    "permissionless": "0.0.35",
+    "permissionless": "0.1.6",
     "viem": "2.7.9"
   },
   "devDependencies": {

--- a/examples/4337-gas-metering/utils/erc20.ts
+++ b/examples/4337-gas-metering/utils/erc20.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv'
 import { http, Address, encodeFunctionData, createWalletClient, PrivateKeyAccount } from 'viem'
-import { goerli, polygonMumbai, sepolia } from 'viem/chains'
+import { goerli, sepolia } from 'viem/chains'
 
 dotenv.config()
 const pimlicoRPCURL = process.env.PIMLICO_RPC_URL
@@ -103,10 +103,10 @@ export const mintERC20Token = async (
         chain: goerli,
         transport: http(pimlicoRPCURL),
       })
-    } else if (chain == 'mumbai') {
+    } else if (chain == 'sepolia') {
       walletClient = createWalletClient({
         account: signer,
-        chain: polygonMumbai,
+        chain: sepolia,
         transport: http(pimlicoRPCURL),
       })
     } else {
@@ -179,10 +179,10 @@ export const transferERC20Token = async (
         chain: goerli,
         transport: http(pimlicoRPCURL),
       })
-    } else if (chain == 'mumbai') {
+    } else if (chain == 'sepolia') {
       walletClient = createWalletClient({
         account: signer,
-        chain: polygonMumbai,
+        chain: sepolia,
         transport: http(pimlicoRPCURL),
       })
     } else {

--- a/examples/4337-gas-metering/utils/nativeTransfer.ts
+++ b/examples/4337-gas-metering/utils/nativeTransfer.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv'
 import { http, createWalletClient, PrivateKeyAccount } from 'viem'
-import { goerli, polygonMumbai, sepolia } from 'viem/chains'
+import { sepolia, baseSepolia } from 'viem/chains'
 import { setTimeout } from 'timers/promises'
 
 dotenv.config()
@@ -18,16 +18,16 @@ export const transferETH = async (
 ) => {
   let walletClient
   if (paymaster == 'pimlico') {
-    if (chain == 'goerli') {
+    if (chain == 'sepolia') {
       walletClient = createWalletClient({
         account: signer,
-        chain: goerli,
+        chain: sepolia,
         transport: http(pimlicoRPCURL),
       })
-    } else if (chain == 'mumbai') {
+    } else if (chain == 'base-sepolia') {
       walletClient = createWalletClient({
         account: signer,
-        chain: polygonMumbai,
+        chain: baseSepolia,
         transport: http(pimlicoRPCURL),
       })
     } else {
@@ -40,12 +40,6 @@ export const transferETH = async (
       walletClient = createWalletClient({
         account: signer,
         chain: sepolia,
-        transport: http(alchemyRPCURL),
-      })
-    } else if (chain == 'goerli') {
-      walletClient = createWalletClient({
-        account: signer,
-        chain: goerli,
         transport: http(alchemyRPCURL),
       })
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,214 @@
         "prettier-plugin-solidity": "^1.3.1"
       }
     },
+    "examples/4337-gas-metering": {
+      "name": "@safe-global/4337-gas-metering",
+      "version": "1.0.0",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@alchemy/aa-accounts": "2.4.0",
+        "@alchemy/aa-alchemy": "2.4.0",
+        "@alchemy/aa-core": "2.3.1",
+        "alchemy-sdk": "3.1.2",
+        "dotenv": "16.4.4",
+        "permissionless": "0.1.6",
+        "viem": "2.7.9"
+      },
+      "devDependencies": {
+        "@types/node": "20.11.18",
+        "rimraf": "^5.0.5",
+        "tsx": "4.7.1",
+        "typescript": "^5.3.3"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/@scure/bip32": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "dependencies": {
+        "@noble/curves": "~1.2.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/abitype": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.0.tgz",
+      "integrity": "sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "examples/4337-gas-metering/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/permissionless": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.1.6.tgz",
+      "integrity": "sha512-Gf8RRaYWdmCh+qSCUUQbBSHX+SXlbEeHDqtHKJFh+NuFTOGmx8pYbDJsQWrqykHOBi0BMJdhNnzElJEmk44nng==",
+      "peerDependencies": {
+        "viem": "^2.0.0"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/rimraf": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "examples/4337-gas-metering/node_modules/viem": {
+      "version": "2.7.9",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.7.9.tgz",
+      "integrity": "sha512-iDfc8TwaZFp1K95zlsxYh6Cs0OWCt35Tqs8uYgXKSxtz7w075mZ0H5SJ8zSyJGoEaticVDhtdmRRX6TtcW9EeQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@scure/bip32": "1.3.2",
+        "@scure/bip39": "1.2.1",
+        "abitype": "1.0.0",
+        "isows": "1.0.3",
+        "ws": "8.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "examples/4337-gas-metering/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "examples/safe-4337-passkeys": {
       "version": "0.0.0",
       "dependencies": {
@@ -198,214 +406,6 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3",
         "yargs": "^17.7.2"
-      }
-    },
-    "examples/4337-gas-metering": {
-      "name": "@safe-global/4337-gas-metering",
-      "version": "1.0.0",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "@alchemy/aa-accounts": "2.4.0",
-        "@alchemy/aa-alchemy": "2.4.0",
-        "@alchemy/aa-core": "2.3.1",
-        "alchemy-sdk": "3.1.2",
-        "dotenv": "16.4.4",
-        "permissionless": "0.0.35",
-        "viem": "2.7.9"
-      },
-      "devDependencies": {
-        "@types/node": "20.11.18",
-        "rimraf": "^5.0.5",
-        "tsx": "4.7.1",
-        "typescript": "^5.3.3"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/@scure/bip32": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
-      "dependencies": {
-        "@noble/curves": "~1.2.0",
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
-      "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/abitype": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.0.tgz",
-      "integrity": "sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "examples/4337-gas-metering/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/permissionless": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.0.35.tgz",
-      "integrity": "sha512-wWnFJW9bCiIBvLVkZ7aPbX0w5LIeelb5dsBOKHIEaRf9xKaxNrpRWCsBRHHjiL0lhvqPlHvEmjJ71Y2mxPyDpg==",
-      "peerDependencies": {
-        "viem": "^2.0.0"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/rimraf": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "examples/4337-gas-metering/node_modules/viem": {
-      "version": "2.7.9",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.7.9.tgz",
-      "integrity": "sha512-iDfc8TwaZFp1K95zlsxYh6Cs0OWCt35Tqs8uYgXKSxtz7w075mZ0H5SJ8zSyJGoEaticVDhtdmRRX6TtcW9EeQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@scure/bip32": "1.3.2",
-        "@scure/bip39": "1.2.1",
-        "abitype": "1.0.0",
-        "isows": "1.0.3",
-        "ws": "8.13.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "examples/4337-gas-metering/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "modules/4337/node_modules/@adraffy/ens-normalize": {
@@ -20391,7 +20391,7 @@
         "@types/node": "20.11.18",
         "alchemy-sdk": "3.1.2",
         "dotenv": "16.4.4",
-        "permissionless": "0.0.35",
+        "permissionless": "0.1.6",
         "rimraf": "^5.0.5",
         "tsx": "4.7.1",
         "typescript": "^5.3.3",
@@ -20468,9 +20468,9 @@
           }
         },
         "permissionless": {
-          "version": "0.0.35",
-          "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.0.35.tgz",
-          "integrity": "sha512-wWnFJW9bCiIBvLVkZ7aPbX0w5LIeelb5dsBOKHIEaRf9xKaxNrpRWCsBRHHjiL0lhvqPlHvEmjJ71Y2mxPyDpg==",
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.1.6.tgz",
+          "integrity": "sha512-Gf8RRaYWdmCh+qSCUUQbBSHX+SXlbEeHDqtHKJFh+NuFTOGmx8pYbDJsQWrqykHOBi0BMJdhNnzElJEmk44nng==",
           "requires": {}
         },
         "rimraf": {


### PR DESCRIPTION
This PR intends to use the latest `EntryPoint v0.7` along with new `paymaster`'s from providers like Pimlico, Alchemy, etc.

## Current Blockers
- Alchemy only supports `v0.6`
- Pimlico Paymasters are still not ready for Production

## Changes completed/in-progress
- Removing `goerli` as it being deprecated.
- Using `base-sepolia` as well (`sepolia` sometimes have high gas cost)
- Using new packed Safe User Op with the latest 4337 Safe Module
- Update of `permissionless` of Pimlico