### PR TITLE
Improving the type definition of `SAFE_ADDRESS_MAP`

### DIFF
--- a/examples/4337-gas-metering/alchemy/alchemy.ts
+++ b/examples/4337-gas-metering/alchemy/alchemy.ts
@@ -59,10 +59,9 @@ if (!txTypes.includes(txType)) {
   throw new Error('TX Type Argument Invalid')
 }
 
-const safeAddresses = (SAFE_ADDRESSES_MAP as Record<string, Record<string, any>>)[safeVersion]
-let chainAddresses
-if (safeAddresses) {
-  chainAddresses = safeAddresses[chainID]
+const chainAddresses = SAFE_ADDRESSES_MAP[safeVersion]?.[chainID]
+if (!chainAddresses) {
+  throw new Error('Missing deployment information for the passed Safe Version & chainID.')
 }
 
 if (apiKey === undefined) {

--- a/examples/4337-gas-metering/gelato/gelato.ts
+++ b/examples/4337-gas-metering/gelato/gelato.ts
@@ -37,10 +37,9 @@ if (!txTypes.includes(txType)) {
   throw new Error('TX Type Argument Invalid')
 }
 
-const safeAddresses = (SAFE_ADDRESSES_MAP as Record<string, Record<string, any>>)[safeVersion]
-let chainAddresses
-if (safeAddresses) {
-  chainAddresses = safeAddresses[chainID]
+const chainAddresses = SAFE_ADDRESSES_MAP[safeVersion]?.[chainID]
+if (!chainAddresses) {
+  throw new Error('Missing deployment information for the passed Safe Version & chainID.')
 }
 
 if (apiKey === undefined) {

--- a/examples/4337-gas-metering/pimlico/pimlico.ts
+++ b/examples/4337-gas-metering/pimlico/pimlico.ts
@@ -51,10 +51,9 @@ if (!txTypes.includes(txType)) {
   throw new Error('TX Type Argument Invalid')
 }
 
-const safeAddresses = (SAFE_ADDRESSES_MAP as Record<string, Record<string, any>>)[safeVersion]
-let chainAddresses
-if (safeAddresses) {
-  chainAddresses = safeAddresses[chainID]
+const chainAddresses = SAFE_ADDRESSES_MAP[safeVersion]?.[chainID]
+if (!chainAddresses) {
+  throw new Error('Missing deployment information for the passed Safe Version & chainID.')
 }
 
 if (apiKey === undefined) {

--- a/examples/4337-gas-metering/utils/address.ts
+++ b/examples/4337-gas-metering/utils/address.ts
@@ -1,4 +1,13 @@
-export const SAFE_ADDRESSES_MAP = {
+import { Address } from 'viem'
+
+export interface SafeAddresses {
+  ADD_MODULES_LIB_ADDRESS: Address
+  SAFE_4337_MODULE_ADDRESS: Address
+  SAFE_PROXY_FACTORY_ADDRESS: Address
+  SAFE_SINGLETON_ADDRESS: Address
+}
+
+export const SAFE_ADDRESSES_MAP: Record<string, Record<string, SafeAddresses | undefined> | undefined> = {
   '1.4.1': {
     '5': {
       ADD_MODULES_LIB_ADDRESS: '0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb',
@@ -25,4 +34,4 @@ export const SAFE_ADDRESSES_MAP = {
       SAFE_SINGLETON_ADDRESS: '0x41675C099F32341bf84BFc5382aF534df5C7461a',
     },
   },
-} as const
+}


### PR DESCRIPTION
This PR just improves the `type` definition of `SAFE_ADDRESS_MAP` to remove some of the linting errors.

P.S. `userOps` linting errors will be solved with either #294 or #316.