### PR TITLE
Correct EIP-7212 Behaviour

### DIFF
--- a/modules/passkey/contracts/interfaces/IP256Verifier.sol
+++ b/modules/passkey/contracts/interfaces/IP256Verifier.sol
@@ -18,9 +18,9 @@ interface IP256Verifier {
      * - `input[ 96:128]`: public key x
      * - `input[128:160]`: public key y
      *
-     * The output is a Solidity ABI encoded boolean value indicating whether or not the signature is
-     * valid. Specifically, it returns 32 bytes with a value of `0x00..00` or `0x00..01` for an
-     * invalid or valid signature respectively.
+     * The output is either:
+     * - `abi.encode(1)` bytes for a valid signature.
+     * - `""` empty bytes for an invalid signature or error.
      *
      * Note that this function does not follow the Solidity ABI format (in particular, it does not
      * have a 4-byte selector), which is why it requires a fallback function and not regular

--- a/modules/passkey/contracts/libraries/P256.sol
+++ b/modules/passkey/contracts/libraries/P256.sol
@@ -80,7 +80,8 @@ library P256 {
             mstore(add(input, 128), y)
 
             // Perform staticcall and check result, note that Yul evaluates expressions from right
-            // to left. See <https://docs.soliditylang.org/en/v0.8.24/yul.html#function-calls>
+            // to left. See <https://docs.soliditylang.org/en/v0.8.24/yul.html#function-calls>.
+            mstore(0, 0)
             success := and(
                 and(
                     // Return data is exactly 32-bytes long

--- a/modules/passkey/contracts/verifiers/FCLP256Verifier.sol
+++ b/modules/passkey/contracts/verifiers/FCLP256Verifier.sol
@@ -16,7 +16,7 @@ contract FCLP256Verifier is IP256Verifier {
      */
     fallback(bytes calldata input) external returns (bytes memory output) {
         if (input.length != 160) {
-            return abi.encodePacked(uint256(0));
+            return "";
         }
 
         bytes32 message;
@@ -34,6 +34,10 @@ contract FCLP256Verifier is IP256Verifier {
             y := calldataload(128)
         }
 
-        output = abi.encode(FCL_ecdsa.ecdsa_verify(message, r, s, x, y));
+        if (!FCL_ecdsa.ecdsa_verify(message, r, s, x, y)) {
+            return "";
+        }
+
+        output = abi.encode(1);
     }
 }


### PR DESCRIPTION
Fixes #309 

This PR fixes an issue where the FCL P-256 verifier behaviour was not following the precompile. In particular, I used the Polygon team implementation:

https://github.com/maticnetwork/bor/blob/43958943edfdfb53f8a7cbe469693b9315fad96b/core/vm/contracts.go#L1209-L1231

To validated expectations, I ran the following script against a Polygon Mumbai execution node to inspect the precompile return values:

<details><summary><code>test-rip-7212.sh</code></summary>

```sh
echo "just right"
curl -s -X POST "$NODE_URL" -H 'Content-Type: application/json' --data '@-' <<JSON | jq -r .result
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000100",
      "data": "0xbb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca6050232ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e184cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd762927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
    },
    "latest"
  ]
}
JSON

echo "mismatch"
curl -s -X POST "$NODE_URL" -H 'Content-Type: application/json' --data '@-' <<JSON | jq -r .result
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000100",
      "data": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e184cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd762927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
    },
    "latest"
  ]
}
JSON

echo "too short"
curl -s -X POST "$NODE_URL" -H 'Content-Type: application/json' --data '@-' <<JSON | jq -r .result
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000100",
      "data": "0xbb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca6050232ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e184cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd762927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e734151"
    },
    "latest"
  ]
}
JSON

echo "too long"
curl -s -X POST "$NODE_URL" -H 'Content-Type: application/json' --data '@-' <<JSON | jq -r .result
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000100",
      "data": "0xbb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca6050232ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e184cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd762927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e00"
    },
    "latest"
  ]
}
JSON

echo "invalid signature r/s"
curl -s -X POST "$NODE_URL" -H 'Content-Type: application/json' --data '@-' <<JSON | jq -r .result
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000100",
      "data": "0xbb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca60502300000000000000000000000000000000000000000000000000000000000000004cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd762927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
    },
    "latest"
  ]
}
JSON

echo "invalid public key"
curl -s -X POST "$NODE_URL" -H 'Content-Type: application/json' --data '@-' <<JSON | jq -r .result
{
  "jsonrpc": "2.0",
  "id": 42,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000100",
      "data": "0xbb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca6050232ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e184cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd762927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
    },
    "latest"
  ]
}
JSON
```

</details>

Indeed, on verification failures (both when inputs are invalid, or the signature doesn't match the message and public key), the empty bytes `0x` are returned instead of `abi.encode(0)`.