### PR TITLE
Fix P-256 Test Account Implementation

### DIFF
--- a/modules/passkey/test/utils/p256.ts
+++ b/modules/passkey/test/utils/p256.ts
@@ -21,7 +21,7 @@ export class Account {
   public sign(message: BytesLike) {
     const hex = ethers.hexlify(message).slice(2)
     const { r, s } = p256.sign(hex, this.privateKey, {
-      lowS: false,
+      lowS: true,
       prehash: false,
     })
 


### PR DESCRIPTION
This PR fixes a small bug in the P-256 account implementation used for tests. It provides an interface that exposes both a high and low S value for a P-256 ECDSA signature, but computes it in a way that the ordering isn't stable (and leads to failed assertions some of the times).

Likely a copy-pasta issue from copying signing code from the `webauthn.ts` module (which does not care abot signature malleability). 