### PR TITLE
User story: Swap passkey owner

### DIFF
--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -171,9 +171,9 @@ describe('Rotate passkey owner [@User story]', () => {
     // Step 3: Execute the userOp to swap the passkey signer
 
     // Send 1 ETH to the Safe
-    await user.sendTransaction({ to: safeAddress, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+    await user.sendTransaction({ to: safeAddress, value: ethers.parseEther('1') })
 
-    await (await entryPoint.handleOps([packedUserOpSwapSigner], user.address)).wait()
+    await entryPoint.handleOps([packedUserOpSwapSigner], user.address)
 
     // Check if new signer is a Safe owner
     expect(await safeInstance.getOwners()).to.deep.equal([user.address, signerNew])

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -131,7 +131,7 @@ describe('Rotate passkey owner [@User story]', () => {
     })
 
     const publicKeyNew = decodePublicKey(credentialNew.response)
-    await (await signerFactory.createSigner(publicKeyNew.x, publicKeyNew.y, verifier.target)).wait()
+    await signerFactory.createSigner(publicKeyNew.x, publicKeyNew.y, verifier.target)
     const signerNew = await signerFactory.getSigner(publicKeyNew.x, publicKeyNew.y, verifier.target)
 
     const interfaceSwapOwner = new ethers.Interface(['function swapOwner(address,address,address)'])

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -24,7 +24,8 @@ import { Log } from 'hardhat-deploy/types'
 describe('Rotate passkey owner [@User story]', () => {
   // Create a fixture to setup the contracts and signer(s)
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier } = await deployments.run()
+    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, WebAuthnSignerFactory } =
+      await deployments.run()
 
     // EOA which will be the owner of the Safe
     const [user] = await ethers.getSigners()
@@ -35,9 +36,7 @@ describe('Rotate passkey owner [@User story]', () => {
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-
-    const WebAuthnSignerFactory = await ethers.getContractFactory('WebAuthnSignerFactory')
-    const signerFactory = await WebAuthnSignerFactory.deploy()
+    const signerFactory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -62,7 +62,7 @@ describe('Rotate passkey owner [@User story]', () => {
     })
 
     const publicKey = decodePublicKey(credential.response)
-    await (await signerFactory.createSigner(publicKey.x, publicKey.y, verifier.target)).wait()
+    await signerFactory.createSigner(publicKey.x, publicKey.y, verifier.target)
     const signer = await signerFactory.getSigner(publicKey.x, publicKey.y, verifier.target)
 
     // The initializer data to enable the Safe4337Module as a module on a Safe

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -1,0 +1,234 @@
+import { expect } from 'chai'
+import { deployments, ethers } from 'hardhat'
+import { WebAuthnCredentials, decodePublicKey } from '../utils/webauthn'
+import { Safe4337Module } from '@safe-global/safe-4337/typechain-types/contracts/Safe4337Module'
+import {
+  buildSafeUserOpTransaction,
+  buildPackedUserOperationFromSafeUserOperation,
+  signSafeOp,
+} from '@safe-global/safe-4337/src/utils/userOp'
+import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
+import { chainId } from '@safe-global/safe-4337/test/utils/encoding'
+
+describe('Rotate passkey owner [@User story]', () => {
+  const setupTests = deployments.createFixture(async ({ deployments }) => {
+    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier } = await deployments.run()
+
+    const [user] = await ethers.getSigners()
+
+    const entryPoint = await ethers.getContractAt('IEntryPoint', EntryPoint.address)
+    const module = (await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)) as unknown as Safe4337Module
+    const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
+    const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
+    const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
+    const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
+
+    const WebAuthnSignerFactory = await ethers.getContractFactory('WebAuthnSignerFactory')
+    const signerFactory = await WebAuthnSignerFactory.deploy()
+
+    const navigator = {
+      credentials: new WebAuthnCredentials(),
+    }
+
+    const credential = navigator.credentials.create({
+      publicKey: {
+        rp: {
+          name: 'Safe',
+          id: 'safe.global',
+        },
+        user: {
+          id: ethers.getBytes(ethers.id('chucknorris')),
+          name: 'chucknorris',
+          displayName: 'Chuck Norris',
+        },
+        challenge: ethers.toBeArray(Date.now()),
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      },
+    })
+
+    const publicKey = decodePublicKey(credential.response)
+    await (await signerFactory.createSigner(publicKey.x, publicKey.y, await verifier.getAddress())).wait()
+    const signer = await signerFactory.getSigner(publicKey.x, publicKey.y, await verifier.getAddress())
+
+    return {
+      user,
+      proxyFactory,
+      safeModuleSetup,
+      module,
+      entryPoint,
+      singleton,
+      signerFactory,
+      navigator,
+      verifier,
+      SafeL2,
+      signer,
+      credential,
+    }
+  })
+
+  it('should execute a userOp with WebAuthn signer as owner', async () => {
+    const {
+      user,
+      proxyFactory,
+      safeModuleSetup,
+      module,
+      entryPoint,
+      verifier,
+      singleton,
+      navigator,
+      SafeL2,
+      signer,
+      signerFactory,
+      credential,
+    } = await setupTests()
+
+    const safeSalt = 1n
+    const initializer = safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]])
+
+    // Deploy a Safe with EOA and passkey signer as owners
+    const setupData = singleton.interface.encodeFunctionData('setup', [
+      [user.address, signer],
+      1n,
+      await safeModuleSetup.getAddress(),
+      initializer,
+      await module.getAddress(),
+      ethers.ZeroAddress,
+      0,
+      ethers.ZeroAddress,
+    ])
+
+    const safe = await proxyFactory.createProxyWithNonce.staticCall(singleton, setupData, safeSalt)
+
+    const deployData = proxyFactory.interface.encodeFunctionData('createProxyWithNonce', [singleton.target, setupData, safeSalt])
+    const initCode = ethers.solidityPacked(['address', 'bytes'], [proxyFactory.target, deployData])
+
+    const safeOp = buildSafeUserOpTransaction(
+      safe,
+      user.address,
+      ethers.parseEther('0.5'),
+      '0x',
+      await entryPoint.getNonce(safe, 0),
+      await entryPoint.getAddress(),
+      false,
+      true,
+      {
+        initCode,
+        verificationGasLimit: 700000,
+        callGasLimit: 2000000,
+        maxFeePerGas: 10000000000,
+        maxPriorityFeePerGas: 10000000000,
+      },
+    )
+
+    const packedUserOp = buildPackedUserOperationFromSafeUserOperation({
+      safeOp,
+      signature: '0x',
+    })
+
+    const signature = buildSignatureBytes([
+      {
+        signer: signer as string,
+        data: buildSignatureBytes([await signSafeOp(user, await module.getAddress(), safeOp, await chainId())]),
+      },
+    ])
+
+    expect(await ethers.provider.getCode(entryPoint)).to.not.equal('0x')
+
+    await user.sendTransaction({ to: safe, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+    expect(await ethers.provider.getBalance(safe)).to.equal(ethers.parseEther('1'))
+    expect(await ethers.provider.getCode(safe)).to.equal('0x')
+
+    await (
+      await entryPoint.handleOps(
+        [
+          {
+            ...packedUserOp,
+            signature: ethers.solidityPacked(['uint48', 'uint48', 'bytes'], [safeOp.validAfter, safeOp.validUntil, signature]),
+          },
+        ],
+        user.address,
+      )
+    ).wait()
+
+    expect(await ethers.provider.getBalance(safe)).to.be.lessThanOrEqual(ethers.parseEther('0.5'))
+    expect(await ethers.provider.getCode(safe)).to.not.equal('0x')
+
+    const [implementation] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], await ethers.provider.getStorage(safe, 0))
+    expect(implementation).to.equal(singleton.target)
+
+    const safeInstance = await ethers.getContractAt(SafeL2.abi, safe)
+    expect(await safeInstance.getOwners()).to.deep.equal([user.address, signer])
+
+    // Swap the signer
+    const credentialNew = navigator.credentials.create({
+      publicKey: {
+        rp: {
+          name: 'Safe',
+          id: 'safe.global',
+        },
+        user: {
+          id: ethers.getBytes(ethers.id('chucknorris')),
+          name: 'chucknorris',
+          displayName: 'Chuck Norris',
+        },
+        challenge: ethers.toBeArray(Date.now()),
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      },
+    })
+
+    const publicKeyNew = decodePublicKey(credentialNew.response)
+    await (await signerFactory.createSigner(publicKeyNew.x, publicKeyNew.y, await verifier.getAddress())).wait()
+    const signerNew = await signerFactory.getSigner(publicKeyNew.x, publicKeyNew.y, await verifier.getAddress())
+
+    const interfaceSwapOwner = new ethers.Interface(['function swapOwner(address,address,address)'])
+
+    const data = interfaceSwapOwner.encodeFunctionData('swapOwner', [user.address, signer, signerNew])
+
+    const safeOpSwapSigner = buildSafeUserOpTransaction(
+      safe,
+      safe,
+      0,
+      data,
+      await entryPoint.getNonce(safe, 0),
+      await entryPoint.getAddress(),
+      false,
+      true,
+      {
+        verificationGasLimit: 700000,
+        callGasLimit: 2000000,
+        maxFeePerGas: 10000000000,
+        maxPriorityFeePerGas: 10000000000,
+      },
+    )
+
+    const packedUserOpSwapSigner = buildPackedUserOperationFromSafeUserOperation({
+      safeOp: safeOpSwapSigner,
+      signature: '0x',
+    })
+
+    const signatureSwapSigner = buildSignatureBytes([
+      {
+        signer: signer as string,
+        data: buildSignatureBytes([await signSafeOp(user, await module.getAddress(), safeOpSwapSigner, await chainId())]),
+      },
+    ])
+
+    // Prepend the signature with 0x000000000000000000000000 to indicate validUntil and validAfter fields
+    await (
+      await entryPoint.handleOps(
+        [
+          {
+            ...packedUserOpSwapSigner,
+            signature: ethers.solidityPacked(
+              ['uint48', 'uint48', 'bytes'],
+              [safeOpSwapSigner.validAfter, safeOpSwapSigner.validUntil, signatureSwapSigner],
+            ),
+          },
+        ],
+        user.address,
+      )
+    ).wait()
+
+    expect(await safeInstance.getOwners()).to.deep.equal([user.address, signerNew])
+  })
+})

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -20,7 +20,7 @@ import { chainId } from '@safe-global/safe-4337/test/utils/encoding'
  * Step 2: Create a userOp to swap the passkey signer, sign it with EOA wallet
  * Step 3: Execute the userOp to swap the passkey signer
  */
-describe('Rotate passkey owner [@User story]', () => {
+describe('Rotate passkey owner [@userstory]', () => {
   // Create a fixture to setup the contracts and signer(s)
   const setupTests = deployments.createFixture(async ({ deployments }) => {
     const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, WebAuthnSignerFactory } =

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -134,8 +134,7 @@ describe('Rotate passkey owner [@User story]', () => {
     await signerFactory.createSigner(publicKeyNew.x, publicKeyNew.y, verifier.target)
     const signerNew = await signerFactory.getSigner(publicKeyNew.x, publicKeyNew.y, verifier.target)
 
-    const interfaceSwapOwner = new ethers.Interface(['function swapOwner(address,address,address)'])
-    const data = interfaceSwapOwner.encodeFunctionData('swapOwner', [user.address, signer, signerNew])
+    const data = safeInstance.interface.encodeFunctionData('swapOwner', [user.address, signer, signerNew])
 
     // Build SafeOp
     const safeOpSwapSigner = buildSafeUserOpTransaction(

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -9,7 +9,6 @@ import {
 } from '@safe-global/safe-4337/src/utils/userOp'
 import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
 import { chainId } from '@safe-global/safe-4337/test/utils/encoding'
-import { Log } from 'hardhat-deploy/types'
 
 /**
  * User story: Rotate passkey owner

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -80,9 +80,8 @@ describe('Rotate passkey owner [@User story]', () => {
 
     // Deploy a Safe with EOA and passkey signer as owners
     const safeSalt = Date.now()
-    const txReceipt = await (await proxyFactory.createProxyWithNonce(singleton, setupData, safeSalt)).wait()
-    // Get Safe address from the event logs
-    const safeAddress = txReceipt.logs.filter((log: Log) => log.address === proxyFactory.target)[0].args[0]
+    const safeAddress = await proxyFactory.createProxyWithNonce.staticCall(singleton, setupData, safeSalt)
+    await proxyFactory.createProxyWithNonce(singleton, setupData, safeSalt)
 
     return {
       user,

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -1,4 +1,4 @@
-// Import necessary dependencies from chai, hardhat, @safe-global, webauthn
+// Import necessary dependencies from chai, hardhat, @safe-global/safe-4337, webauthn
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 import { WebAuthnCredentials, decodePublicKey } from '../utils/webauthn'

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -31,7 +31,7 @@ describe('Rotate passkey owner [@User story]', () => {
     const [user] = await ethers.getSigners()
 
     const entryPoint = await ethers.getContractAt('IEntryPoint', EntryPoint.address)
-    const module = (await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)) as unknown as Safe4337Module
+    const module = await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)
     const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)

--- a/modules/passkey/test/userStories/rotatePasskeyOwner.ts
+++ b/modules/passkey/test/userStories/rotatePasskeyOwner.ts
@@ -2,7 +2,6 @@
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 import { WebAuthnCredentials, decodePublicKey } from '../utils/webauthn'
-import { Safe4337Module } from '@safe-global/safe-4337/typechain-types/contracts/Safe4337Module'
 import {
   buildSafeUserOpTransaction,
   buildPackedUserOperationFromSafeUserOperation,
@@ -147,10 +146,7 @@ describe('Rotate passkey owner [@User story]', () => {
       false,
       true,
       {
-        verificationGasLimit: 700000,
-        callGasLimit: 2000000,
-        maxFeePerGas: 10000000000,
-        maxPriorityFeePerGas: 10000000000,
+        verificationGasLimit: 100000,
       },
     )
 


### PR DESCRIPTION
Fixes #279 

Changes in PR:

- Add a test case to showcase that a Passkey signer for a Safe can be replaced with new signer. The signer is replaced by an EOA which is also a Safe owner.

Tasks:

- Add test case
- Add comments