### PR TITLE
User story: Execute userOp with Passkey signer

### DIFF
--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -1,0 +1,212 @@
+import { expect } from 'chai'
+import { deployments, ethers } from 'hardhat'
+import { WebAuthnCredentials, decodePublicKey, encodeWebAuthnSignature } from '../utils/webauthn'
+import { Safe4337Module } from '@safe-global/safe-4337/typechain-types/contracts/Safe4337Module'
+import { buildSafeUserOpTransaction, buildPackedUserOperationFromSafeUserOperation } from '@safe-global/safe-4337/src/utils/userOp'
+import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
+
+describe('Execute UserOp from Passkey signer [@User story]', () => {
+  const setupTests = deployments.createFixture(async ({ deployments }) => {
+    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier } = await deployments.run()
+
+    const [user] = await ethers.getSigners()
+
+    const entryPoint = await ethers.getContractAt('IEntryPoint', EntryPoint.address)
+    const module = (await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)) as unknown as Safe4337Module
+    const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
+    const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
+    const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
+    const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
+
+    const WebAuthnSignerFactory = await ethers.getContractFactory('WebAuthnSignerFactory')
+    const signerFactory = await WebAuthnSignerFactory.deploy()
+
+    const navigator = {
+      credentials: new WebAuthnCredentials(),
+    }
+
+    const credential = navigator.credentials.create({
+      publicKey: {
+        rp: {
+          name: 'Safe',
+          id: 'safe.global',
+        },
+        user: {
+          id: ethers.getBytes(ethers.id('chucknorris')),
+          name: 'chucknorris',
+          displayName: 'Chuck Norris',
+        },
+        challenge: ethers.toBeArray(Date.now()),
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      },
+    })
+
+    const publicKey = decodePublicKey(credential.response)
+    await (await signerFactory.createSigner(publicKey.x, publicKey.y, await verifier.getAddress())).wait()
+    const signer = await signerFactory.getSigner(publicKey.x, publicKey.y, await verifier.getAddress())
+
+    return {
+      user,
+      proxyFactory,
+      safeModuleSetup,
+      module,
+      entryPoint,
+      singleton,
+      signerFactory,
+      navigator,
+      verifier,
+      SafeL2,
+      signer,
+      credential,
+    }
+  })
+
+  it('should execute a userOp with WebAuthn signer as owner', async () => {
+    const { user, proxyFactory, safeModuleSetup, module, entryPoint, singleton, navigator, SafeL2, signer, credential } = await setupTests()
+
+    const safeSalt = 1n
+    const initializer = safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]])
+
+    const setupData = singleton.interface.encodeFunctionData('setup', [
+      [signer],
+      1n,
+      await safeModuleSetup.getAddress(),
+      initializer,
+      await module.getAddress(),
+      ethers.ZeroAddress,
+      0,
+      ethers.ZeroAddress,
+    ])
+
+    const safe = await proxyFactory.createProxyWithNonce.staticCall(singleton, setupData, safeSalt)
+
+    const deployData = proxyFactory.interface.encodeFunctionData('createProxyWithNonce', [singleton.target, setupData, safeSalt])
+    const initCode = ethers.solidityPacked(['address', 'bytes'], [proxyFactory.target, deployData])
+
+    const safeOp = buildSafeUserOpTransaction(
+      safe,
+      user.address,
+      ethers.parseEther('0.0'),
+      '0x',
+      await entryPoint.getNonce(safe, 0),
+      await entryPoint.getAddress(),
+      false,
+      true,
+      {
+        initCode,
+        verificationGasLimit: 700000,
+        callGasLimit: 2000000,
+        maxFeePerGas: 10000000000,
+        maxPriorityFeePerGas: 10000000000,
+      },
+    )
+
+    const packedUserOp = buildPackedUserOperationFromSafeUserOperation({
+      safeOp,
+      signature: '0x',
+    })
+
+    const opHash = await module.getOperationHash(packedUserOp)
+
+    const assertion = navigator.credentials.get({
+      publicKey: {
+        challenge: ethers.getBytes(opHash),
+        rpId: 'safe.global',
+        allowCredentials: [{ type: 'public-key', id: new Uint8Array(credential.rawId) }],
+        userVerification: 'required',
+      },
+    })
+
+    const signature = buildSignatureBytes([
+      {
+        signer: signer as string,
+        data: encodeWebAuthnSignature(assertion.response),
+        dynamic: true,
+      },
+    ])
+
+    expect(await ethers.provider.getCode(entryPoint)).to.not.equal('0x')
+
+    await user.sendTransaction({ to: safe, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+    expect(await ethers.provider.getBalance(safe)).to.equal(ethers.parseEther('1'))
+    expect(await ethers.provider.getCode(safe)).to.equal('0x')
+
+    await (
+      await entryPoint.handleOps(
+        [
+          {
+            ...packedUserOp,
+            signature: ethers.solidityPacked(['uint48', 'uint48', 'bytes'], [safeOp.validAfter, safeOp.validUntil, signature]),
+          },
+        ],
+        user.address,
+      )
+    ).wait()
+
+    expect(await ethers.provider.getCode(safe)).to.not.equal('0x')
+
+    const [implementation] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], await ethers.provider.getStorage(safe, 0))
+    expect(implementation).to.equal(singleton.target)
+
+    const safeInstance = await ethers.getContractAt(SafeL2.abi, safe)
+    expect(await safeInstance.getOwners()).to.deep.equal([signer])
+
+    // Execute the userOp from passkey signer
+    const safeOp2 = buildSafeUserOpTransaction(
+      safe,
+      ethers.ZeroAddress,
+      ethers.parseEther('0.2'),
+      '0x',
+      await entryPoint.getNonce(safe, 0),
+      await entryPoint.getAddress(),
+      false,
+      true,
+      {
+        verificationGasLimit: 700000,
+        callGasLimit: 2000000,
+        maxFeePerGas: 10000000000,
+        maxPriorityFeePerGas: 10000000000,
+      },
+    )
+
+    const packedUserOp2 = buildPackedUserOperationFromSafeUserOperation({
+      safeOp: safeOp2,
+      signature: '0x',
+    })
+
+    const opHash2 = await module.getOperationHash(packedUserOp2)
+
+    const assertion2 = navigator.credentials.get({
+      publicKey: {
+        challenge: ethers.getBytes(opHash2),
+        rpId: 'safe.global',
+        allowCredentials: [{ type: 'public-key', id: new Uint8Array(credential.rawId) }],
+        userVerification: 'required',
+      },
+    })
+
+    const signature2 = buildSignatureBytes([
+      {
+        signer: signer as string,
+        data: encodeWebAuthnSignature(assertion2.response),
+        dynamic: true,
+      },
+    ])
+
+    const balanceBefore = await ethers.provider.getBalance(ethers.ZeroAddress)
+
+    await (
+      await entryPoint.handleOps(
+        [
+          {
+            ...packedUserOp2,
+            signature: ethers.solidityPacked(['uint48', 'uint48', 'bytes'], [safeOp2.validAfter, safeOp2.validUntil, signature2]),
+          },
+        ],
+        user.address,
+      )
+    ).wait()
+
+    expect(await ethers.provider.getBalance(ethers.ZeroAddress)).to.be.equal(balanceBefore + ethers.parseEther('0.2'))
+  })
+})

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -144,7 +144,7 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
 
     const balanceBefore = await ethers.provider.getBalance(ethers.ZeroAddress)
 
-    await (await entryPoint.handleOps([packedUserOp], relayer.address)).wait()
+    await entryPoint.handleOps([packedUserOp], relayer.address)
 
     // Check if the address(0) received 0.2 ETH
     expect(await ethers.provider.getBalance(ethers.ZeroAddress)).to.be.equal(balanceBefore + ethers.parseEther('0.2'))

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -17,7 +17,8 @@ import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
  */
 describe('Execute userOp from Passkey signer [@User story]', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier } = await deployments.run()
+    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, WebAuthnSignerFactory } =
+      await deployments.run()
 
     const [relayer] = await ethers.getSigners()
 
@@ -27,9 +28,7 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-
-    const WebAuthnSignerFactory = await ethers.getContractFactory('WebAuthnSignerFactory')
-    const signerFactory = await WebAuthnSignerFactory.deploy()
+    const signerFactory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -123,7 +123,7 @@ describe('Execute userOp from Passkey signer [@userstory]', () => {
     // Build contract signature that the Safe will forward to the signer contract
     const signature2 = buildSignatureBytes([
       {
-        signer: signer as string,
+        signer: signer,
         data: encodeWebAuthnSignature(assertion.response),
         dynamic: true,
       },

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -15,7 +15,7 @@ import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
  * Step 2: Create a userOp and sign it using passkey credential.
  * Step 3: Execute the userOp.
  */
-describe('Execute userOp from Passkey signer [@User story]', () => {
+describe('Execute userOp from Passkey signer [@userstory]', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
     const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, WebAuthnSignerFactory } =
       await deployments.run()

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -5,6 +5,7 @@ import { WebAuthnCredentials, decodePublicKey, encodeWebAuthnSignature } from '.
 import { Safe4337Module } from '@safe-global/safe-4337/typechain-types/contracts/Safe4337Module'
 import { buildSafeUserOpTransaction, buildPackedUserOperationFromSafeUserOperation } from '@safe-global/safe-4337/src/utils/userOp'
 import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
+import { Log } from 'hardhat-deploy/types'
 
 /**
  * User story: Execute userOp from Passkey signer
@@ -13,10 +14,8 @@ import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
  *
  * The flow can be summarized as follows:
  * Step 1: Setup the contracts.
- * Step 2: Create a userOp, sign it with Passkey signer.
- * Step 3: Execute the userOp that deploys a safe with passkey signer as owner.
- * Step 4: Create a userOp and sign it using passkey credential.
- * Step 5: Execute the userOp.
+ * Step 2: Create a userOp and sign it using passkey credential.
+ * Step 3: Execute the userOp.
  */
 describe('Execute userOp from Passkey signer [@User story]', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
@@ -56,8 +55,31 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
 
     // Deploy a signer contract
     const publicKey = decodePublicKey(credential.response)
-    await (await signerFactory.createSigner(publicKey.x, publicKey.y, await verifier.getAddress())).wait()
+    await signerFactory.createSigner(publicKey.x, publicKey.y, await verifier.getAddress())
     const signer = await signerFactory.getSigner(publicKey.x, publicKey.y, await verifier.getAddress())
+
+    // Deploy a Safe with passkey signer as owner
+
+    // The initializer data to enable the Safe4337Module as a module on a Safe
+    const initializer = safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]])
+
+    // Create setup data to deploy a Safe with EOA and passkey signer as owners, threshold 1, Safe4337Module as module and fallback handler
+    const setupData = singleton.interface.encodeFunctionData('setup', [
+      [signer],
+      1n,
+      safeModuleSetup.target,
+      initializer,
+      module.target,
+      ethers.ZeroAddress,
+      0,
+      ethers.ZeroAddress,
+    ])
+
+    // Deploy a Safe with EOA and passkey signer as owners
+    const safeSalt = Date.now()
+    const txReceipt = await (await proxyFactory.createProxyWithNonce(singleton, setupData, safeSalt)).wait()
+    // Get Safe address from the event logs
+    const safeAddress = txReceipt.logs.filter((log: Log) => log.address === proxyFactory.target)[0].args[0]
 
     return {
       user,
@@ -72,107 +94,21 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
       SafeL2,
       signer,
       credential,
+      safeAddress,
     }
   })
 
   it('should execute a userOp with WebAuthn signer as owner', async () => {
     // Step 1: Setup the contracts
-    const { user, proxyFactory, safeModuleSetup, module, entryPoint, singleton, navigator, SafeL2, signer, credential } = await setupTests()
-
-    // Step 2: Create a userOp, sign it with Passkey signer.
-    const safeSalt = Date.now()
-    const initializer = safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]])
-
-    const setupData = singleton.interface.encodeFunctionData('setup', [
-      [signer],
-      1n,
-      await safeModuleSetup.getAddress(),
-      initializer,
-      await module.getAddress(),
-      ethers.ZeroAddress,
-      0,
-      ethers.ZeroAddress,
-    ])
-
-    // Predict the Safe address to construct the userOp
-    const safe = await proxyFactory.createProxyWithNonce.staticCall(singleton, setupData, safeSalt)
-
-    const deployData = proxyFactory.interface.encodeFunctionData('createProxyWithNonce', [singleton.target, setupData, safeSalt])
-
-    // Create safeOp
-    const safeOp = buildSafeUserOpTransaction(
-      safe,
-      user.address,
-      ethers.parseEther('0.0'),
-      '0x',
-      await entryPoint.getNonce(safe, 0),
-      await entryPoint.getAddress(),
-      false,
-      true,
-      {
-        initCode: ethers.solidityPacked(['address', 'bytes'], [proxyFactory.target, deployData]),
-        verificationGasLimit: 700000,
-      },
-    )
-
-    const packedUserOp = buildPackedUserOperationFromSafeUserOperation({
-      safeOp,
-      signature: '0x',
-    })
-
-    const opHash = await module.getOperationHash(packedUserOp)
-
-    const assertion = navigator.credentials.get({
-      publicKey: {
-        challenge: ethers.getBytes(opHash),
-        rpId: 'safe.global',
-        allowCredentials: [{ type: 'public-key', id: new Uint8Array(credential.rawId) }],
-        userVerification: 'required',
-      },
-    })
-
-    // Build contract signature that the Safe will forward to the signer contract
-    const signature = buildSignatureBytes([
-      {
-        signer: signer as string,
-        data: encodeWebAuthnSignature(assertion.response),
-        dynamic: true,
-      },
-    ])
-
-    // Send 1 ETH to the Safe
-    await user.sendTransaction({ to: safe, value: ethers.parseEther('1') }).then((tx) => tx.wait())
-    // Check if Safe is not already created
-    expect(await ethers.provider.getCode(safe)).to.equal('0x')
-
-    // Step 3: Execute the userOp that deploys a safe with passkey signer as owner.
-    await (
-      await entryPoint.handleOps(
-        [
-          {
-            ...packedUserOp,
-            signature: ethers.solidityPacked(['uint48', 'uint48', 'bytes'], [safeOp.validAfter, safeOp.validUntil, signature]),
-          },
-        ],
-        user.address,
-      )
-    ).wait()
-
-    // Check if Safe is created and uses the expected Singleton
-    const [implementation] = ethers.AbiCoder.defaultAbiCoder().decode(['address'], await ethers.provider.getStorage(safe, 0))
-    expect(implementation).to.equal(singleton.target)
-
-    // Check the owners of the created Safe
-    const safeInstance = await ethers.getContractAt(SafeL2.abi, safe)
-    expect(await safeInstance.getOwners()).to.deep.equal([signer])
+    const { user, module, entryPoint, navigator, signer, credential, safeAddress } = await setupTests()
 
     // Step 4: Create a userOp and sign it using passkey credential.
     const safeOp2 = buildSafeUserOpTransaction(
-      safe,
+      safeAddress,
       ethers.ZeroAddress,
       ethers.parseEther('0.2'),
       '0x',
-      await entryPoint.getNonce(safe, 0),
+      await entryPoint.getNonce(safeAddress, 0),
       await entryPoint.getAddress(),
       false,
       true,
@@ -206,6 +142,10 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
     const balanceBefore = await ethers.provider.getBalance(ethers.ZeroAddress)
 
     // Step 5: Execute the userOp.
+
+    // Send 1 ETH to the Safe
+    await user.sendTransaction({ to: safeAddress, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+
     await (
       await entryPoint.handleOps(
         [
@@ -220,5 +160,6 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
 
     // Check if the address(0) the 0.2 ETH
     expect(await ethers.provider.getBalance(ethers.ZeroAddress)).to.be.equal(balanceBefore + ethers.parseEther('0.2'))
+    expect(await ethers.provider.getBalance(safeAddress)).to.be.lessThanOrEqual(ethers.parseEther('1') - ethers.parseEther('0.2'))
   })
 })

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -133,7 +133,7 @@ describe('Execute userOp from Passkey signer [@userstory]', () => {
 
     // Step 3: Execute the userOp.
 
-    // Send 1 ETH to the Safe
+    // Send 1 ETH to the Safe for the transaction and the prefund
     await relayer.sendTransaction({ to: safeAddress, value: ethers.parseEther('1') })
 
     const balanceBefore = await ethers.provider.getBalance(ethers.ZeroAddress)

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -92,7 +92,7 @@ describe('Execute userOp from Passkey signer [@userstory]', () => {
     // Step 1: Setup the contracts
     const { relayer, module, entryPoint, navigator, signer, credential, safeAddress } = await setupTests()
 
-    // Step 4: Create a userOp and sign it using passkey credential.
+    // Step 2: Create a userOp and sign it using passkey credential.
     const safeOp = buildSafeUserOpTransaction(
       safeAddress,
       ethers.ZeroAddress,
@@ -131,7 +131,7 @@ describe('Execute userOp from Passkey signer [@userstory]', () => {
 
     packedUserOp.signature = ethers.solidityPacked(['uint48', 'uint48', 'bytes'], [safeOp.validAfter, safeOp.validUntil, signature2])
 
-    // Step 5: Execute the userOp.
+    // Step 3: Execute the userOp.
 
     // Send 1 ETH to the Safe
     await relayer.sendTransaction({ to: safeAddress, value: ethers.parseEther('1') })

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -24,7 +24,7 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
     const [user] = await ethers.getSigners()
 
     const entryPoint = await ethers.getContractAt('IEntryPoint', EntryPoint.address)
-    const module = (await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)) as unknown as Safe4337Module
+    const module = await ethers.getContractAt('Safe4337Module', Safe4337Module.address)
     const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -79,15 +79,9 @@ describe('Execute userOp from Passkey signer [@userstory]', () => {
 
     return {
       relayer,
-      proxyFactory,
-      safeModuleSetup,
       module,
       entryPoint,
-      singleton,
-      signerFactory,
       navigator,
-      verifier,
-      SafeL2,
       signer,
       credential,
       safeAddress,

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -140,7 +140,7 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
     // Step 5: Execute the userOp.
 
     // Send 1 ETH to the Safe
-    await relayer.sendTransaction({ to: safeAddress, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+    await relayer.sendTransaction({ to: safeAddress, value: ethers.parseEther('1') })
 
     const balanceBefore = await ethers.provider.getBalance(ethers.ZeroAddress)
 

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -146,7 +146,7 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
 
     await (await entryPoint.handleOps([packedUserOp], relayer.address)).wait()
 
-    // Check if the address(0) the 0.2 ETH
+    // Check if the address(0) received 0.2 ETH
     expect(await ethers.provider.getBalance(ethers.ZeroAddress)).to.be.equal(balanceBefore + ethers.parseEther('0.2'))
     expect(await ethers.provider.getBalance(safeAddress)).to.be.lessThanOrEqual(ethers.parseEther('1') - ethers.parseEther('0.2'))
   })

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -1,4 +1,3 @@
-// Import necessary dependencies from chai, hardhat, @safe-global/safe-4337, webauthn
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 import { WebAuthnCredentials, decodePublicKey, encodeWebAuthnSignature } from '../utils/webauthn'
@@ -74,6 +73,7 @@ describe('Execute userOp from Passkey signer [@userstory]', () => {
 
     // Deploy a Safe with EOA and passkey signer as owners
     const safeSalt = Date.now()
+    // Calculate the address of the Safe. Alternatively, address can be retrieved from the event logs or by calculating it off-chain via create2.
     const safeAddress = await proxyFactory.createProxyWithNonce.staticCall(singleton, setupData, safeSalt)
     await proxyFactory.createProxyWithNonce(singleton, setupData, safeSalt)
 
@@ -89,7 +89,6 @@ describe('Execute userOp from Passkey signer [@userstory]', () => {
   })
 
   it('should execute a userOp with WebAuthn signer as owner', async () => {
-    // Step 1: Setup the contracts
     const { relayer, module, entryPoint, navigator, signer, credential, safeAddress } = await setupTests()
 
     // Step 2: Create a userOp and sign it using passkey credential.

--- a/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
+++ b/modules/passkey/test/userStories/executeUserOpFromPasskeySigner.ts
@@ -77,9 +77,8 @@ describe('Execute userOp from Passkey signer [@User story]', () => {
 
     // Deploy a Safe with EOA and passkey signer as owners
     const safeSalt = Date.now()
-    const txReceipt = await (await proxyFactory.createProxyWithNonce(singleton, setupData, safeSalt)).wait()
-    // Get Safe address from the event logs
-    const safeAddress = txReceipt.logs.filter((log: Log) => log.address === proxyFactory.target)[0].args[0]
+    const safeAddress = await proxyFactory.createProxyWithNonce.staticCall(singleton, setupData, safeSalt)
+    await proxyFactory.createProxyWithNonce(singleton, setupData, safeSalt)
 
     return {
       user,


### PR DESCRIPTION
Fixes #277 

Changes in PR:

- Add a test case to showcase that a Passkey signer can sign a `userOp` and execute transactions through a Safe. 

Tasks:

- Add test case
- Add comments