### PR TITLE
Add NPM Benchmarking Script

### DIFF
--- a/modules/passkey/package.json
+++ b/modules/passkey/package.json
@@ -27,6 +27,7 @@
     "build"
   ],
   "scripts": {
+    "bench": "hardhat test --grep @bench",
     "build": "npm run build:sol && npm run build:ts",
     "build:sol": "rimraf build typechain-types && hardhat compile",
     "build:ts": "rimraf dist && tsc",

--- a/modules/passkey/test/GasBenchmarking.spec.ts
+++ b/modules/passkey/test/GasBenchmarking.spec.ts
@@ -4,7 +4,7 @@ import { deployments, ethers } from 'hardhat'
 import { WebAuthnCredentials, decodePublicKey, encodeWebAuthnSignature } from './utils/webauthn'
 import { IP256Verifier } from '../typechain-types'
 
-describe('Gas Benchmarking', function () {
+describe('Gas Benchmarking [@bench]', function () {
   const navigator = {
     credentials: new WebAuthnCredentials(),
   }


### PR DESCRIPTION
In order to explore some small code improvements, this PR adds a new NPM script to the passkey module to make it easier to invoke only the benchmark tests.