### PR TITLE
Manually Implement SHA-256 Precompile Call

### DIFF
--- a/modules/passkey/contracts/test/TestWebAuthnLib.sol
+++ b/modules/passkey/contracts/test/TestWebAuthnLib.sol
@@ -16,7 +16,7 @@ contract TestWebAuthnLib {
         bytes32 challenge,
         bytes calldata authenticatorData,
         string calldata clientDataFields
-    ) external pure returns (bytes32 message) {
+    ) external view returns (bytes32 message) {
         message = WebAuthn.signingMessage(challenge, authenticatorData, clientDataFields);
     }
 


### PR DESCRIPTION
When looking for low-hanging fruit for gas optimisations, I noticed that Solidity was generating copy loops when calling the SHA-256 precompile, even if the input was already in memory!

This PR provides a work around where we re-implement the SHA-256 precompile manually in a way that it never copies the input before doing the `staticcall`. This gives us some substantial gas savings, both in terms of deployment costs and runtime costs:

<details><summary>Before:</summary>

```
  Gas Benchmarking [@bench]
    WebAuthnSigner
      ⛽ deployment: 515421
      ✔ Benchmark signer deployment cost (765ms)
      ⛽ verification (Dummy): 12106
      ✔ Benchmark signer verification cost with Dummy verifier
```

</details>

<details><summary>After:</summary>

```
  Gas Benchmarking [@bench]
    WebAuthnSigner
      ⛽ deployment: 471398
      ✔ Benchmark signer deployment cost (761ms)
      ⛽ verification (Dummy): 11148
      ✔ Benchmark signer verification cost with Dummy verifier
```

</details>