### PR TITLE
Generalize Signing Message Encoding

### DIFF
--- a/modules/passkey/contracts/libraries/WebAuthn.sol
+++ b/modules/passkey/contracts/libraries/WebAuthn.sol
@@ -277,6 +277,11 @@ library WebAuthn {
         uint256 y,
         IP256Verifier verifier
     ) internal view returns (bool success) {
+        // The order of operations here is slightly counter-intuitive (in particular, you do not
+        // need to encode the signing message if the expected authenticator flags are missing).
+        // However, ordering things this way helps the Solidity compiler generate meaningfully more
+        // optimal code for the "happy path" when Yul optimizations are turned on.
+
         bytes memory message = encodeSigningMessage(challenge, signature.authenticatorData, signature.clientDataFields);
         if (checkAuthenticatorFlags(signature.authenticatorData, authenticatorFlags)) {
             success = verifier.verifySignatureAllowMalleability(_sha256(message), signature.r, signature.s, x, y);

--- a/modules/passkey/contracts/test/TestWebAuthnLib.sol
+++ b/modules/passkey/contracts/test/TestWebAuthnLib.sol
@@ -12,12 +12,12 @@ contract TestWebAuthnLib {
         clientDataJson = WebAuthn.encodeClientDataJson(challenge, clientDataFields);
     }
 
-    function signingMessage(
+    function encodeSigningMessage(
         bytes32 challenge,
         bytes calldata authenticatorData,
         string calldata clientDataFields
-    ) external view returns (bytes32 message) {
-        message = WebAuthn.signingMessage(challenge, authenticatorData, clientDataFields);
+    ) external view returns (bytes memory message) {
+        message = WebAuthn.encodeSigningMessage(challenge, authenticatorData, clientDataFields);
     }
 
     function verifySignatureCastSig(

--- a/modules/passkey/test/libraries/WebAuthn.spec.ts
+++ b/modules/passkey/test/libraries/WebAuthn.spec.ts
@@ -47,9 +47,9 @@ describe('WebAuthn Library', () => {
         origin: 'http://safe.global',
       }
       const clientDataHash = ethers.sha256(ethers.toUtf8Bytes(JSON.stringify(clientData)))
-      const message = ethers.sha256(ethers.concat([authenticatorData, clientDataHash]))
+      const message = ethers.concat([authenticatorData, clientDataHash])
 
-      expect(await webAuthnLib.signingMessage(challenge, authenticatorData, `"origin":"http://safe.global"`)).to.equal(message)
+      expect(await webAuthnLib.encodeSigningMessage(challenge, authenticatorData, `"origin":"http://safe.global"`)).to.equal(message)
     })
   })
 


### PR DESCRIPTION
Closes #292 

This PR generalizes the `WebAuthn` library to work better with future public key algorithms that we may want to implement. Notably, the hashing algorithm used for signing depends on the public key algorithm of the credential, and is not always SHA-256. In contrast, the client data JSON is **always** hashed with SHA-256. As such, we refactored the function to return the actual signing message before hashing, so it can be more easily composed in the eventuality that we start to support other algorithms.

We also refactor encoding to be done in assembly for some small gas wins, because Solidity is double copying the authenticator data.

<details><summary>Before:</summary>

```
  Gas Benchmarking [@bench]
    WebAuthnSigner
      ⛽ deployment: 471398
      ✔ Benchmark signer deployment cost (761ms)
      ⛽ verification (Dummy): 11148
      ✔ Benchmark signer verification cost with Dummy verifier
```

</details>

<details><summary>After:</summary>

```
  Gas Benchmarking [@bench]
    WebAuthnSigner
      ⛽ deployment: 468188
      ✔ Benchmark signer deployment cost (744ms)
      ⛽ verification (Dummy): 11126
      ✔ Benchmark signer verification cost with Dummy verifier
```

</details>

A more significant change is the re-ordering of operations in the `verifySignature` function. This is a workaround to https://github.com/ethereum/solidity/issues/14934 as it "tricks" the Yul IR optimizer to perform much better (especially WRT code size) when Yul optimizations are enabled:

<details><summary>Before (with Yul IR optimizations):</summary>

```
  Gas Benchmarking [@bench]
    WebAuthnSigner
      ⛽ deployment: 515182
      ✔ Benchmark signer deployment cost (742ms)
      ⛽ verification (Dummy): 9958
      ✔ Benchmark signer verification cost with Dummy verifier
```

</details>

<details><summary>After (with Yul IR optimizations):</summary>

```
  Gas Benchmarking [@bench]
    WebAuthnSigner
      ⛽ deployment: 470475
      ✔ Benchmark signer deployment cost (727ms)
      ⛽ verification (Dummy): 9624
      ✔ Benchmark signer verification cost with Dummy verifier
```

</details>