### PR TITLE
Rename WebAuthn Contracts

### DIFF
--- a/examples/4337-passkeys/README.md
+++ b/examples/4337-passkeys/README.md
@@ -1,6 +1,6 @@
 # Safe + 4337 + Passkeys example application
 
-This minimalistic example application demonstrates a Safe{Core} Smart Account deployment leveraging 4337 and Passkeys. It uses experimental and unaudited (at the moment of writing) contracts: [TestSafeSignerLaunchpad](https://github.com/safe-global/safe-modules/blob/959b0d3b420ce6d7d15811363e4b8fcc4640ae32/modules/4337/contracts/test/TestSafeSignerLaunchpad.sol) and [WebAuthnSigner](https://github.com/safe-global/safe-modules/blob/main/modules/4337/contracts/experimental/WebAuthnSigner.sol), which uses [FreshCryptoLib](https://github.com/rdubois-crypto/FreshCryptoLib/) under the hood.
+This minimalistic example application demonstrates a Safe{Core} Smart Account deployment leveraging 4337 and Passkeys. It uses experimental and unaudited (at the moment of writing) contracts: [SafeECDSASignerLaunchpad](https://github.com/safe-global/safe-modules/blob/main/modules/passkey/contracts/4337/SafeECDSASignerLaunchpad.sol) and [SafeWebAuthnSigner](https://github.com/safe-global/safe-modules/blob/main/modules/passkey/contracts/SafeWebAuthnSigner.sol), which uses [FreshCryptoLib](https://github.com/rdubois-crypto/FreshCryptoLib/) under the hood.
 
 ## Running the app
 

--- a/examples/4337-passkeys/src/logic/safe.ts
+++ b/examples/4337-passkeys/src/logic/safe.ts
@@ -1,15 +1,15 @@
 import { ethers } from 'ethers'
 import { abi as SafeECDSASignerLaunchpadAbi } from '@safe-global/safe-passkey/build/artifacts/contracts/4337/SafeECDSASignerLaunchpad.sol/SafeECDSASignerLaunchpad.json'
-import { abi as WebAuthnSignerFactoryAbi } from '@safe-global/safe-passkey/build/artifacts/contracts/WebAuthnSignerFactory.sol/WebAuthnSignerFactory.json'
+import { abi as SafeWebAuthnSignerFactoryAbi } from '@safe-global/safe-passkey/build/artifacts/contracts/SafeWebAuthnSignerFactory.sol/SafeWebAuthnSignerFactory.json'
 import { abi as SetupModuleSetupAbi } from '@safe-global/safe-4337/build/artifacts/contracts/SafeModuleSetup.sol/SafeModuleSetup.json'
 import {
-  abi as WebAuthnSignerAbi,
+  abi as SafeWebAuthnSignerAbi,
   bytecode as WebAuthSignerBytecode,
-} from '@safe-global/safe-passkey/build/artifacts/contracts/WebAuthnSigner.sol/WebAuthnSigner.json'
+} from '@safe-global/safe-passkey/build/artifacts/contracts/SafeWebAuthnSigner.sol/SafeWebAuthnSigner.json'
 import { abi as Safe4337ModuleAbi } from '@safe-global/safe-4337/build/artifacts/contracts/Safe4337Module.sol/Safe4337Module.json'
 import { abi as SafeProxyFactoryAbi } from '@safe-global/safe-4337/build/artifacts/@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol/SafeProxyFactory.json'
 import type { Safe4337Module, SafeProxyFactory, SafeModuleSetup } from '@safe-global/safe-4337/typechain-types/'
-import type { SafeECDSASignerLaunchpad, WebAuthnSigner, WebAuthnSignerFactory } from '@safe-global/safe-passkey/typechain-types/'
+import type { SafeECDSASignerLaunchpad, SafeWebAuthnSigner, SafeWebAuthnSignerFactory } from '@safe-global/safe-passkey/typechain-types/'
 
 import {
   SAFE_SIGNER_LAUNCHPAD_ADDRESS,
@@ -47,24 +47,24 @@ function getSafe4337ModuleContract(provider: ethers.JsonRpcProvider): Safe4337Mo
 }
 
 /**
- * Returns an instance of the WebAuthnSignerFactory contract.
+ * Returns an instance of the SafeWebAuthnSignerFactory contract.
  *
  * @param provider - The JSON-RPC provider used to interact with the Ethereum network.
- * @returns An instance of the WebAuthnSignerFactory contract.
+ * @returns An instance of the SafeWebAuthnSignerFactory contract.
  */
-function getWebAuthnSignerFactoryContract(provider: ethers.JsonRpcProvider): WebAuthnSignerFactory {
-  return new ethers.Contract(WEBAUTHN_SIGNER_FACTORY_ADDRESS, WebAuthnSignerFactoryAbi, { provider }) as unknown as WebAuthnSignerFactory
+function getSafeWebAuthnSignerFactoryContract(provider: ethers.JsonRpcProvider): SafeWebAuthnSignerFactory {
+  return new ethers.Contract(WEBAUTHN_SIGNER_FACTORY_ADDRESS, SafeWebAuthnSignerFactoryAbi, { provider }) as unknown as SafeWebAuthnSignerFactory
 }
 
 /**
- * Creates a WebAuthnSigner contract instance.
+ * Creates a SafeWebAuthnSigner contract instance.
  *
  * @param provider - The JSON-RPC provider.
  * @param address - The address of the contract.
- * @returns The WebAuthnSigner contract instance.
+ * @returns The SafeWebAuthnSigner contract instance.
  */
-function getWebAuthnSignerContract(provider: ethers.JsonRpcProvider, address: string): WebAuthnSigner {
-  return new ethers.Contract(address, WebAuthnSignerAbi, { provider }) as unknown as WebAuthnSigner
+function getSafeWebAuthnSignerContract(provider: ethers.JsonRpcProvider, address: string): SafeWebAuthnSigner {
+  return new ethers.Contract(address, SafeWebAuthnSignerAbi, { provider }) as unknown as SafeWebAuthnSigner
 }
 
 /**
@@ -232,8 +232,8 @@ export {
   getLaunchpadInitializeThenUserOpData,
   getSafeSignerLaunchpadContract,
   getSafe4337ModuleContract,
-  getWebAuthnSignerFactoryContract,
-  getWebAuthnSignerContract,
+  getSafeWebAuthnSignerFactoryContract,
+  getSafeWebAuthnSignerContract,
   getSignerAddressFromPubkeyCoords,
   getSafeDeploymentData,
   getSafeAddress,

--- a/examples/4337-passkeys/src/logic/safe.ts
+++ b/examples/4337-passkeys/src/logic/safe.ts
@@ -53,7 +53,9 @@ function getSafe4337ModuleContract(provider: ethers.JsonRpcProvider): Safe4337Mo
  * @returns An instance of the SafeWebAuthnSignerFactory contract.
  */
 function getSafeWebAuthnSignerFactoryContract(provider: ethers.JsonRpcProvider): SafeWebAuthnSignerFactory {
-  return new ethers.Contract(WEBAUTHN_SIGNER_FACTORY_ADDRESS, SafeWebAuthnSignerFactoryAbi, { provider }) as unknown as SafeWebAuthnSignerFactory
+  return new ethers.Contract(WEBAUTHN_SIGNER_FACTORY_ADDRESS, SafeWebAuthnSignerFactoryAbi, {
+    provider,
+  }) as unknown as SafeWebAuthnSignerFactory
 }
 
 /**

--- a/modules/passkey/contracts/SafeWebAuthnSigner.sol
+++ b/modules/passkey/contracts/SafeWebAuthnSigner.sol
@@ -10,7 +10,7 @@ import {WebAuthn} from "./libraries/WebAuthn.sol";
  * @dev A contract that represents a WebAuthn signer.
  * @custom:security-contact bounty@safe.global
  */
-contract WebAuthnSigner is SignatureValidator {
+contract SafeWebAuthnSigner is SignatureValidator {
     uint256 public immutable X;
     uint256 public immutable Y;
     IP256Verifier public immutable VERIFIER;

--- a/modules/passkey/contracts/SafeWebAuthnSignerFactory.sol
+++ b/modules/passkey/contracts/SafeWebAuthnSignerFactory.sol
@@ -5,18 +5,18 @@ import {ICustomECDSASignerFactory} from "./interfaces/ICustomECDSASignerFactory.
 import {IP256Verifier} from "./interfaces/IP256Verifier.sol";
 import {ERC1271} from "./libraries/ERC1271.sol";
 import {WebAuthn} from "./libraries/WebAuthn.sol";
-import {WebAuthnSigner} from "./WebAuthnSigner.sol";
+import {SafeWebAuthnSigner} from "./SafeWebAuthnSigner.sol";
 
 /**
  * @title WebAuthnSignerFactory
  * @dev A factory contract for creating and managing WebAuthn signers.
  */
-contract WebAuthnSignerFactory is ICustomECDSASignerFactory {
+contract SafeWebAuthnSignerFactory is ICustomECDSASignerFactory {
     /**
      * @inheritdoc ICustomECDSASignerFactory
      */
     function getSigner(uint256 x, uint256 y, address verifier) public view override returns (address signer) {
-        bytes32 codeHash = keccak256(abi.encodePacked(type(WebAuthnSigner).creationCode, x, y, uint256(uint160(verifier))));
+        bytes32 codeHash = keccak256(abi.encodePacked(type(SafeWebAuthnSigner).creationCode, x, y, uint256(uint160(verifier))));
         signer = address(uint160(uint256(keccak256(abi.encodePacked(hex"ff", address(this), bytes32(0), codeHash)))));
     }
 
@@ -27,7 +27,7 @@ contract WebAuthnSignerFactory is ICustomECDSASignerFactory {
         signer = getSigner(x, y, verifier);
 
         if (_hasNoCode(signer)) {
-            WebAuthnSigner created = new WebAuthnSigner{salt: bytes32(0)}(x, y, verifier);
+            SafeWebAuthnSigner created = new SafeWebAuthnSigner{salt: bytes32(0)}(x, y, verifier);
             require(address(created) == signer);
         }
     }

--- a/modules/passkey/contracts/libraries/P256.sol
+++ b/modules/passkey/contracts/libraries/P256.sol
@@ -6,7 +6,7 @@ import {IP256Verifier} from "../interfaces/IP256Verifier.sol";
 /**
  * @title P-256 Elliptic Curve Verification Library.
  * @dev Library P-256 verification with contracts that follows the EIP-7212 EC verify precompile
- * interface. See <https://eips.ethereum.org/EIPS/eip-7212>
+ * interface. See <https://eips.ethereum.org/EIPS/eip-7212>.
  * @custom:security-contact bounty@safe.global
  */
 library P256 {

--- a/modules/passkey/src/deploy/webauthn.ts
+++ b/modules/passkey/src/deploy/webauthn.ts
@@ -4,7 +4,7 @@ const deploy: DeployFunction = async ({ deployments, getNamedAccounts }) => {
   const { deployer } = await getNamedAccounts()
   const { deploy } = deployments
 
-  await deploy('WebAuthnSignerFactory', {
+  await deploy('SafeWebAuthnSignerFactory', {
     from: deployer,
     args: [],
     log: true,

--- a/modules/passkey/test/4337/WebAuthn.spec.ts
+++ b/modules/passkey/test/4337/WebAuthn.spec.ts
@@ -21,7 +21,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
       Safe4337Module,
       SafeECDSASignerLaunchpad,
       EntryPoint,
-      WebAuthnSignerFactory,
+      SafeWebAuthnSignerFactory,
     } = await deployments.fixture()
 
     const [user] = await ethers.getSigners()
@@ -32,7 +32,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
     const signerLaunchpad = await ethers.getContractAt('SafeECDSASignerLaunchpad', SafeECDSASignerLaunchpad.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-    const signerFactory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),
@@ -227,7 +227,10 @@ describe('Safe4337Module - WebAuthn Owner', () => {
       })
       const publicKey = decodePublicKey(credential.response)
       await signerFactory.createSigner(publicKey.x, publicKey.y, verifierAddress)
-      const signer = await ethers.getContractAt('WebAuthnSigner', await signerFactory.getSigner(publicKey.x, publicKey.y, verifierAddress))
+      const signer = await ethers.getContractAt(
+        'SafeWebAuthnSigner',
+        await signerFactory.getSigner(publicKey.x, publicKey.y, verifierAddress),
+      )
 
       const safe = await Safe4337.withSigner(await signer.getAddress(), {
         safeSingleton: await singleton.getAddress(),

--- a/modules/passkey/test/4337/WebAuthnSigner.spec.ts
+++ b/modules/passkey/test/4337/WebAuthnSigner.spec.ts
@@ -20,7 +20,7 @@ describe('WebAuthn Signers [@4337]', () => {
       SafeModuleSetup,
       SafeL2,
       FCLP256Verifier,
-      WebAuthnSignerFactory,
+      SafeWebAuthnSignerFactory,
     } = await deployments.run()
     const [user] = await prepareAccounts()
     const bundler = bundlerRpc()
@@ -32,7 +32,7 @@ describe('WebAuthn Signers [@4337]', () => {
     const signerLaunchpad = await ethers.getContractAt('SafeECDSASignerLaunchpad', SafeECDSASignerLaunchpad.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-    const signerFactory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),

--- a/modules/passkey/test/GasBenchmarking.spec.ts
+++ b/modules/passkey/test/GasBenchmarking.spec.ts
@@ -25,12 +25,12 @@ describe('Gas Benchmarking [@bench]', function () {
   })
 
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { DaimoP256Verifier, FCLP256Verifier, WebAuthnSignerFactory } = await deployments.fixture()
+    const { DaimoP256Verifier, FCLP256Verifier, SafeWebAuthnSignerFactory } = await deployments.fixture()
 
     const Benchmarker = await ethers.getContractFactory('Benchmarker')
     const benchmarker = await Benchmarker.deploy()
 
-    const factory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
+    const factory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
 
     const DummyP256Verifier = await ethers.getContractFactory('DummyP256Verifier')
     const verifiers = {
@@ -42,7 +42,7 @@ describe('Gas Benchmarking [@bench]', function () {
     return { benchmarker, factory, verifiers }
   })
 
-  describe('WebAuthnSigner', () => {
+  describe('SafeWebAuthnSigner', () => {
     it(`Benchmark signer deployment cost`, async function () {
       const { benchmarker, factory } = await setupTests()
 
@@ -76,7 +76,7 @@ describe('Gas Benchmarking [@bench]', function () {
         const verifier = verifiers[key]
 
         await factory.createSigner(x, y, verifier)
-        const signer = await ethers.getContractAt('WebAuthnSigner', await factory.getSigner(x, y, verifier))
+        const signer = await ethers.getContractAt('SafeWebAuthnSigner', await factory.getSigner(x, y, verifier))
         const signature = encodeWebAuthnSignature(assertion.response)
 
         const [gas, returnData] = await benchmarker.call.staticCall(

--- a/modules/passkey/test/userstories/CreateSafeWithPasskeySignerAsOwner.spec.ts
+++ b/modules/passkey/test/userstories/CreateSafeWithPasskeySignerAsOwner.spec.ts
@@ -17,7 +17,7 @@ import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
 describe('Create a Safe with Passkey signer as owner: [@userstory]', () => {
   // Create a fixture to setup the contracts and signer(s)
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, WebAuthnSignerFactory } =
+    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, SafeWebAuthnSignerFactory } =
       await deployments.run()
 
     const [user] = await ethers.getSigners()
@@ -28,7 +28,7 @@ describe('Create a Safe with Passkey signer as owner: [@userstory]', () => {
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-    const signerFactory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),

--- a/modules/passkey/test/userstories/ExecuteUserOpFromPasskeySigner.spec.ts
+++ b/modules/passkey/test/userstories/ExecuteUserOpFromPasskeySigner.spec.ts
@@ -16,7 +16,7 @@ import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
  */
 describe('Execute userOp from Passkey signer [@userstory]', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, WebAuthnSignerFactory } =
+    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, SafeWebAuthnSignerFactory } =
       await deployments.run()
 
     const [relayer] = await ethers.getSigners()
@@ -27,7 +27,7 @@ describe('Execute userOp from Passkey signer [@userstory]', () => {
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-    const signerFactory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),

--- a/modules/passkey/test/userstories/OffchainPasskeyVerification.spec.ts
+++ b/modules/passkey/test/userstories/OffchainPasskeyVerification.spec.ts
@@ -14,13 +14,13 @@ import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
  */
 describe('Offchain Passkey Signature Verification [@userstory]', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { SafeProxyFactory, SafeL2, FCLP256Verifier, WebAuthnSignerFactory, CompatibilityFallbackHandler } = await deployments.run()
+    const { SafeProxyFactory, SafeL2, FCLP256Verifier, SafeWebAuthnSignerFactory, CompatibilityFallbackHandler } = await deployments.run()
 
     const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const fallbackHandler = await ethers.getContractAt(CompatibilityFallbackHandler.abi, CompatibilityFallbackHandler.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-    const signerFactory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),
@@ -49,7 +49,7 @@ describe('Offchain Passkey Signature Verification [@userstory]', () => {
     const publicKey = decodePublicKey(credential.response)
     await signerFactory.createSigner(publicKey.x, publicKey.y, verifierAddress)
     const signerAddress = await signerFactory.getSigner(publicKey.x, publicKey.y, verifierAddress)
-    const signer = await ethers.getContractAt('WebAuthnSigner', signerAddress)
+    const signer = await ethers.getContractAt('SafeWebAuthnSigner', signerAddress)
 
     // Deploy Safe with the WebAuthn signer as a single owner.
     const singletonAddress = await singleton.getAddress()

--- a/modules/passkey/test/userstories/RotatePasskeyOwner.spec.ts
+++ b/modules/passkey/test/userstories/RotatePasskeyOwner.spec.ts
@@ -23,7 +23,7 @@ import { chainId } from '@safe-global/safe-4337/test/utils/encoding'
 describe('Rotate passkey owner [@userstory]', () => {
   // Create a fixture to setup the contracts and signer(s)
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, WebAuthnSignerFactory } =
+    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, SafeWebAuthnSignerFactory } =
       await deployments.run()
 
     // EOA which will be the owner of the Safe
@@ -35,7 +35,7 @@ describe('Rotate passkey owner [@userstory]', () => {
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-    const signerFactory = await ethers.getContractAt('WebAuthnSignerFactory', WebAuthnSignerFactory.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),


### PR DESCRIPTION
This PR keeps up with the Safe's proud naming tradition of having all contract names be prefixed with Safe-.