### PR TITLE
NatSpec and Unit Test Coverage for `SafeWebAuthnSigner`

### DIFF
--- a/modules/passkey/contracts/SafeWebAuthnSigner.sol
+++ b/modules/passkey/contracts/SafeWebAuthnSigner.sol
@@ -7,18 +7,29 @@ import {WebAuthn} from "./libraries/WebAuthn.sol";
 
 /**
  * @title WebAuthn Safe Signature Validator
- * @dev A contract that represents a WebAuthn signer.
+ * @dev A Safe signature validator implementation for a WebAuthn P-256 credential.
  * @custom:security-contact bounty@safe.global
  */
 contract SafeWebAuthnSigner is SignatureValidator {
+    /**
+     * @notice The X coordinate of the P-256 public key of the WebAuthn credential.
+     */
     uint256 public immutable X;
+
+    /**
+     * @notice The Y coordinate of the P-256 public key of the WebAuthn credential.
+     */
     uint256 public immutable Y;
+
+    /**
+     * @notice The P-256 verifier used for ECDSA signature validation.
+     */
     IP256Verifier public immutable VERIFIER;
 
     /**
      * @dev Constructor function.
-     * @param x The X coordinate of the signer's public key.
-     * @param y The Y coordinate of the signer's public key.
+     * @param x The X coordinate of the P-256 public key of the WebAuthn credential.
+     * @param y The Y coordinate of the P-256 public key of the WebAuthn credential.
      * @param verifier The P-256 verifier to use for signature validation. It MUST implement the
      * same interface as the EIP-7212 precompile.
      */

--- a/modules/passkey/test/SafeWebAuthnSigner.spec.ts
+++ b/modules/passkey/test/SafeWebAuthnSigner.spec.ts
@@ -1,0 +1,127 @@
+import { expect } from 'chai'
+import { deployments, ethers } from 'hardhat'
+import { DUMMY_AUTHENTICATOR_DATA, base64UrlEncode, encodeWebAuthnSigningMessage, getSignatureBytes } from './utils/webauthn'
+
+describe('SafeWebAuthnSigner', () => {
+  const setupTests = deployments.createFixture(async () => {
+    const x = ethers.id('publicKey.x')
+    const y = ethers.id('publicKey.y')
+    const MockContract = await ethers.getContractFactory('MockContract')
+    const mockVerifier = await MockContract.deploy()
+    const SafeWebAuthnSigner = await ethers.getContractFactory('SafeWebAuthnSigner')
+    const signer = await SafeWebAuthnSigner.deploy(x, y, mockVerifier)
+
+    return { x, y, mockVerifier, signer }
+  })
+
+  describe('constructor', function () {
+    it('Should set immutables', async () => {
+      const { x, y, mockVerifier, signer } = await setupTests()
+
+      expect(await signer.X()).to.equal(x)
+      expect(await signer.Y()).to.equal(y)
+      expect(await signer.VERIFIER()).to.equal(mockVerifier.target)
+    })
+  })
+
+  describe('isValidSignature', function () {
+    it('Should return true when the verifier returns true', async () => {
+      const { x, y, mockVerifier, signer } = await setupTests()
+
+      const data = ethers.toUtf8Bytes('some data to sign')
+      const dataHash = ethers.keccak256(data)
+
+      const clientData = {
+        type: 'webauthn.get' as const,
+        challenge: base64UrlEncode(dataHash),
+        origin: 'https://safe.global',
+      }
+
+      const r = ethers.id('signature.r')
+      const s = ethers.id('signature.s')
+
+      const signature = getSignatureBytes({
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: '"origin":"https://safe.global"',
+        r,
+        s,
+      })
+
+      await mockVerifier.givenCalldataReturnBool(
+        ethers.solidityPacked(
+          ['bytes32', 'uint256', 'uint256', 'uint256', 'uint256'],
+          [ethers.sha256(encodeWebAuthnSigningMessage(clientData, DUMMY_AUTHENTICATOR_DATA)), r, s, x, y],
+        ),
+        true,
+      )
+
+      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.equal('0x1626ba7e')
+      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.equal('0x20c13b0b')
+    })
+
+    it('Should return false when the verifier does not return true', async () => {
+      const { x, y, mockVerifier, signer } = await setupTests()
+
+      const data = ethers.toUtf8Bytes('some data to sign')
+      const dataHash = ethers.keccak256(data)
+
+      const clientData = {
+        type: 'webauthn.get' as const,
+        challenge: base64UrlEncode(dataHash),
+        origin: 'https://safe.global',
+      }
+
+      const r = ethers.id('signature.r')
+      const s = ethers.id('signature.s')
+
+      const signature = getSignatureBytes({
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: '"origin":"https://safe.global"',
+        r,
+        s,
+      })
+
+      await mockVerifier.givenAnyReturnBool(true)
+      await mockVerifier.givenCalldataReturn(
+        ethers.solidityPacked(
+          ['bytes32', 'uint256', 'uint256', 'uint256', 'uint256'],
+          [ethers.sha256(encodeWebAuthnSigningMessage(clientData, DUMMY_AUTHENTICATOR_DATA)), r, s, x, y],
+        ),
+        '0xfe',
+      )
+
+      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.not.equal('0x1626ba7e')
+      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.not.equal('0x20c13b0b')
+    })
+
+    it('Should return false on non-matching authenticator flags', async () => {
+      const { mockVerifier, signer } = await setupTests()
+
+      const data = ethers.toUtf8Bytes('some data to sign')
+      const dataHash = ethers.keccak256(data)
+
+      const authenticatorData = ethers.solidityPacked(
+        ['bytes32', 'uint8', 'uint32'],
+        [
+          ethers.toBeHex(ethers.MaxUint256),
+          0, // no flags
+          0xffffffff, // signCount
+        ],
+      )
+
+      const r = ethers.id('signature.r')
+      const s = ethers.id('signature.s')
+
+      const signature = getSignatureBytes({
+        authenticatorData,
+        clientDataFields: '"origin":"https://safe.global"',
+        r,
+        s,
+      })
+
+      await mockVerifier.givenAnyReturnBool(true)
+      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.not.equal('0x1626ba7e')
+      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.not.equal('0x20c13b0b')
+    })
+  })
+})


### PR DESCRIPTION
This PR adds some missing NatSpec documentation to the `SafeWebAuthnSigner` contract (notably the `immutable`s) and implements missing coverage for the contract. In the unit and E2E tests, we only ever call the `isValidSignature(bytes,bytes)` function, and never the `isValidSignature(bytes32,bytes)`.

Related to #365 