### PR TITLE
Use ERC-1271 Constants In Tests

### DIFF
--- a/modules/passkey/test/GasBenchmarking.spec.ts
+++ b/modules/passkey/test/GasBenchmarking.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 
+import * as ERC1271 from './utils/erc1271'
 import { WebAuthnCredentials, decodePublicKey, encodeWebAuthnSignature } from './utils/webauthn'
 import { IP256Verifier } from '../typechain-types'
 
@@ -85,7 +86,7 @@ describe('Gas Benchmarking [@bench]', function () {
         )
 
         const [magicValue] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes4'], returnData)
-        expect(magicValue).to.equal('0x1626ba7e')
+        expect(magicValue).to.equal(ERC1271.MAGIC_VALUE)
 
         console.log(`      ⛽ verification (${name}): ${gas}`)
       })

--- a/modules/passkey/test/SafeWebAuthnSigner.spec.ts
+++ b/modules/passkey/test/SafeWebAuthnSigner.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
+
+import * as ERC1271 from './utils/erc1271'
 import { DUMMY_AUTHENTICATOR_DATA, base64UrlEncode, encodeWebAuthnSigningMessage, getSignatureBytes } from './utils/webauthn'
 
 describe('SafeWebAuthnSigner', () => {
@@ -55,8 +57,8 @@ describe('SafeWebAuthnSigner', () => {
         true,
       )
 
-      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.equal('0x1626ba7e')
-      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.equal('0x20c13b0b')
+      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.equal(ERC1271.MAGIC_VALUE)
+      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.equal(ERC1271.LEGACY_MAGIC_VALUE)
     })
 
     it('Should return false when the verifier does not return true', async () => {
@@ -90,8 +92,8 @@ describe('SafeWebAuthnSigner', () => {
         '0xfe',
       )
 
-      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.not.equal('0x1626ba7e')
-      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.not.equal('0x20c13b0b')
+      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.not.equal(ERC1271.MAGIC_VALUE)
+      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.not.equal(ERC1271.LEGACY_MAGIC_VALUE)
     })
 
     it('Should return false on non-matching authenticator flags', async () => {
@@ -120,8 +122,8 @@ describe('SafeWebAuthnSigner', () => {
       })
 
       await mockVerifier.givenAnyReturnBool(true)
-      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.not.equal('0x1626ba7e')
-      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.not.equal('0x20c13b0b')
+      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.not.equal(ERC1271.MAGIC_VALUE)
+      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.not.equal(ERC1271.LEGACY_MAGIC_VALUE)
     })
   })
 })

--- a/modules/passkey/test/SafeWebAuthnSignerFactory.spec.ts
+++ b/modules/passkey/test/SafeWebAuthnSignerFactory.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
+
+import * as ERC1271 from './utils/erc1271'
 import { DUMMY_AUTHENTICATOR_DATA, base64UrlEncode, encodeWebAuthnSigningMessage, getSignatureBytes } from './utils/webauthn'
 
 describe('SafeWebAuthnSignerFactory', () => {
@@ -113,7 +115,7 @@ describe('SafeWebAuthnSignerFactory', () => {
         true,
       )
 
-      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.equal('0x1626ba7e')
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.equal(ERC1271.MAGIC_VALUE)
     })
 
     it('Should return false when the verifier does not return true', async () => {
@@ -147,7 +149,7 @@ describe('SafeWebAuthnSignerFactory', () => {
         '0xfe',
       )
 
-      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.not.equal('0x1626ba7e')
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.not.equal(ERC1271.MAGIC_VALUE)
     })
 
     it('Should return false on non-matching authenticator flags', async () => {
@@ -176,7 +178,7 @@ describe('SafeWebAuthnSignerFactory', () => {
       })
 
       await mockVerifier.givenAnyReturnBool(true)
-      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.not.equal('0x1626ba7e')
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.not.equal(ERC1271.MAGIC_VALUE)
     })
   })
 })

--- a/modules/passkey/test/userstories/OffchainPasskeyVerification.spec.ts
+++ b/modules/passkey/test/userstories/OffchainPasskeyVerification.spec.ts
@@ -1,7 +1,9 @@
+import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
+
+import * as ERC1271 from '../utils/erc1271'
 import { WebAuthnCredentials, decodePublicKey, encodeWebAuthnSignature } from '../utils/webauthn'
-import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
 
 /**
  * User story: Off-chain Passkey Signature Verification
@@ -109,6 +111,6 @@ describe('Offchain Passkey Signature Verification [@userstory]', () => {
       },
     ])
 
-    expect(await safe['isValidSignature(bytes32,bytes)'](message, signature)).to.eq('0x1626ba7e')
+    expect(await safe['isValidSignature(bytes32,bytes)'](message, signature)).to.eq(ERC1271.MAGIC_VALUE)
   })
 })

--- a/modules/passkey/test/utils/erc1271.ts
+++ b/modules/passkey/test/utils/erc1271.ts
@@ -1,0 +1,2 @@
+export const MAGIC_VALUE = '0x1626ba7e'
+export const LEGACY_MAGIC_VALUE = '0x20c13b0b'


### PR DESCRIPTION
Addresses https://github.com/safe-global/safe-modules/pull/371#pullrequestreview-1988230595 (cc @remedcu)

This PR addresses a comment to use constants for ERC-1271 magic values to make the tests easier to read.