### PR TITLE
Support Precompile With Fallback For Signers

### DIFF
--- a/examples/4337-passkeys/README.md
+++ b/examples/4337-passkeys/README.md
@@ -1,6 +1,6 @@
 # Safe + 4337 + Passkeys example application
 
-This minimalistic example application demonstrates a Safe{Core} Smart Account deployment leveraging 4337 and Passkeys. It uses experimental and unaudited (at the moment of writing) contracts: [SafeECDSASignerLaunchpad](https://github.com/safe-global/safe-modules/blob/main/modules/passkey/contracts/4337/SafeECDSASignerLaunchpad.sol) and [SafeWebAuthnSigner](https://github.com/safe-global/safe-modules/blob/main/modules/passkey/contracts/SafeWebAuthnSigner.sol), which uses [FreshCryptoLib](https://github.com/rdubois-crypto/FreshCryptoLib/) under the hood.
+This minimalistic example application demonstrates a Safe{Core} Smart Account deployment leveraging 4337 and Passkeys. It uses experimental and unaudited (at the moment of writing) contracts: [SafeSignerLaunchpad](https://github.com/safe-global/safe-modules/blob/main/modules/passkey/contracts/4337/SafeSignerLaunchpad.sol) and [SafeWebAuthnSigner](https://github.com/safe-global/safe-modules/blob/main/modules/passkey/contracts/SafeWebAuthnSigner.sol), which uses [FreshCryptoLib](https://github.com/rdubois-crypto/FreshCryptoLib/) under the hood.
 
 ## Running the app
 

--- a/examples/4337-passkeys/src/logic/safe.ts
+++ b/examples/4337-passkeys/src/logic/safe.ts
@@ -1,11 +1,11 @@
 import { ethers } from 'ethers'
-import { abi as SafeECDSASignerLaunchpadAbi } from '@safe-global/safe-passkey/build/artifacts/contracts/4337/SafeECDSASignerLaunchpad.sol/SafeECDSASignerLaunchpad.json'
+import { abi as SafeSignerLaunchpadAbi } from '@safe-global/safe-passkey/build/artifacts/contracts/4337/SafeSignerLaunchpad.sol/SafeSignerLaunchpad.json'
 import { abi as SetupModuleSetupAbi } from '@safe-global/safe-4337/build/artifacts/contracts/SafeModuleSetup.sol/SafeModuleSetup.json'
-import { bytecode as WebAuthSignerBytecode } from '@safe-global/safe-passkey/build/artifacts/contracts/SafeWebAuthnSigner.sol/SafeWebAuthnSigner.json'
+import { bytecode as SafeWebAuthSignerBytecode } from '@safe-global/safe-passkey/build/artifacts/contracts/SafeWebAuthnSigner.sol/SafeWebAuthnSigner.json'
 import { abi as Safe4337ModuleAbi } from '@safe-global/safe-4337/build/artifacts/contracts/Safe4337Module.sol/Safe4337Module.json'
 import { abi as SafeProxyFactoryAbi } from '@safe-global/safe-4337/build/artifacts/@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol/SafeProxyFactory.json'
 import type { Safe4337Module, SafeModuleSetup, SafeProxyFactory } from '@safe-global/safe-4337/typechain-types/'
-import type { SafeECDSASignerLaunchpad } from '@safe-global/safe-passkey/typechain-types/'
+import type { SafeSignerLaunchpad } from '@safe-global/safe-passkey/typechain-types/'
 
 import {
   P256_VERIFIER_ADDRESS,
@@ -28,7 +28,7 @@ const SafeProxyBytecode =
 function getSignerAddressFromPubkeyCoords(x: string, y: string): string {
   const deploymentCode = ethers.solidityPacked(
     ['bytes', 'uint256', 'uint256', 'uint256'],
-    [WebAuthSignerBytecode, x, y, P256_VERIFIER_ADDRESS],
+    [SafeWebAuthSignerBytecode, x, y, P256_VERIFIER_ADDRESS],
   )
   const salt = ethers.ZeroHash
   return ethers.getCreate2Address(WEBAUTHN_SIGNER_FACTORY_ADDRESS, salt, ethers.keccak256(deploymentCode))
@@ -65,7 +65,7 @@ function getInitHash(safeInitializer: SafeInitializer, chainId: ethers.BigNumber
 }
 
 function getLaunchpadInitializer(safeInitHash: string, optionalCallAddress = ethers.ZeroAddress, optionalCalldata = '0x'): string {
-  const safeSignerLaunchpadInterface = new ethers.Interface(SafeECDSASignerLaunchpadAbi) as unknown as SafeECDSASignerLaunchpad['interface']
+  const safeSignerLaunchpadInterface = new ethers.Interface(SafeSignerLaunchpadAbi) as unknown as SafeSignerLaunchpad['interface']
 
   const launchpadInitializer = safeSignerLaunchpadInterface.encodeFunctionData('preValidationSetup', [
     safeInitHash,
@@ -127,7 +127,7 @@ function encodeSafeModuleSetupCall(modules: string[]): string {
  * @returns The encoded data for initializing the Safe contract and performing the user operation.
  */
 function getLaunchpadInitializeThenUserOpData(initializer: SafeInitializer, encodedUserOp: string): string {
-  const safeSignerLaunchpadInterface = new ethers.Interface(SafeECDSASignerLaunchpadAbi) as unknown as SafeECDSASignerLaunchpad['interface']
+  const safeSignerLaunchpadInterface = new ethers.Interface(SafeSignerLaunchpadAbi) as unknown as SafeSignerLaunchpad['interface']
 
   const initializeThenUserOpData = safeSignerLaunchpadInterface.encodeFunctionData('initializeThenUserOp', [
     initializer.singleton,

--- a/modules/passkey/contracts/4337/SafeSignerLaunchpad.sol
+++ b/modules/passkey/contracts/4337/SafeSignerLaunchpad.sol
@@ -41,7 +41,7 @@ contract SafeSignerLaunchpad is IAccount, SafeStorage {
      *  {address} signerFactory - The custom ECDSA signer factory to use for creating an owner.
      *  {uint256} signerX - The X coordinate of the public key of the custom ECDSA signing scheme.
      *  {uint256} signerY - The Y coordinate of the public key of the custom ECDSA signing scheme.
-     *  {uint256} signerVerifiers - The ECDSA verifier contract used by the custom signing scheme.
+     *  {uint256} signerVerifiers - The P-256 verifiers to use for signature validation.
      *  {address} setupTo - The contract to `DELEGATECALL` during setup.
      *  {bytes} setupData - The calldata for the setup `DELEGATECALL`.
      *  {address} fallbackHandler - The fallback handler to initialize the Safe with.
@@ -132,7 +132,7 @@ contract SafeSignerLaunchpad is IAccount, SafeStorage {
      * @param signerFactory The custom ECDSA signer factory to use for creating an owner.
      * @param signerX The X coordinate of the signer's public key.
      * @param signerY The Y coordinate of the signer's public key.
-     * @param signerVerifiers The address of the contract that verifies the signer's signature.
+     * @param signerVerifiers The P-256 verifiers to use for signature validation.
      * @param setupTo The contract to `DELEGATECALL` during setup.
      * @param setupData The calldata for the setup `DELEGATECALL`.
      * @param fallbackHandler The fallback handler to initialize the Safe with.
@@ -252,7 +252,7 @@ contract SafeSignerLaunchpad is IAccount, SafeStorage {
      * @param signerFactory The custom ECDSA signer factory to use for creating an owner.
      * @param signerX The X coordinate of the signer's public key.
      * @param signerY The Y coordinate of the signer's public key.
-     * @param signerVerifiers The address of the contract that verifies the signer's signature.
+     * @param signerVerifiers The P-256 verifiers to use for signature validation.
      * @param setupTo The contract to `DELEGATECALL` during setup.
      * @param setupData The calldata for the setup `DELEGATECALL`.
      * @param fallbackHandler The fallback handler to initialize the Safe with.
@@ -307,7 +307,7 @@ contract SafeSignerLaunchpad is IAccount, SafeStorage {
      * @param signerFactory The custom ECDSA signer factory to use for creating an owner.
      * @param signerX The X coordinate of the signer's public key.
      * @param signerY The Y coordinate of the signer's public key.
-     * @param signerVerifiers The address of the contract that verifies the signer's signature.
+     * @param signerVerifiers The P-256 verifiers to use for signature validation.
      * @return validationData An integer indicating the result of the validation.
      */
     function _validateSignatures(

--- a/modules/passkey/contracts/4337/SafeSignerLaunchpad.sol
+++ b/modules/passkey/contracts/4337/SafeSignerLaunchpad.sol
@@ -6,7 +6,7 @@ import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/Pac
 import {_packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
 import {SafeStorage} from "@safe-global/safe-contracts/contracts/libraries/SafeStorage.sol";
 
-import {ICustomECDSASignerFactory} from "../interfaces/ICustomECDSASignerFactory.sol";
+import {ISafeSignerFactory, P256} from "../interfaces/ISafeSignerFactory.sol";
 import {ISafe} from "../interfaces/ISafe.sol";
 import {ERC1271} from "../libraries/ERC1271.sol";
 
@@ -20,7 +20,7 @@ import {ERC1271} from "../libraries/ERC1271.sol";
  * `threshold` during the `setup` phase.
  * @custom:security-contact bounty@safe.global
  */
-contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
+contract SafeSignerLaunchpad is IAccount, SafeStorage {
     /**
      * @notice The EIP-712 type-hash for the domain separator used for verifying Safe initialization signatures.
      * @custom:computed-as keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
@@ -41,13 +41,13 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
      *  {address} signerFactory - The custom ECDSA signer factory to use for creating an owner.
      *  {uint256} signerX - The X coordinate of the public key of the custom ECDSA signing scheme.
      *  {uint256} signerY - The Y coordinate of the public key of the custom ECDSA signing scheme.
-     *  {uint256} signerVerifier - The ECDSA verifier contract used by the custom signing scheme.
+     *  {uint256} signerVerifiers - The ECDSA verifier contract used by the custom signing scheme.
      *  {address} setupTo - The contract to `DELEGATECALL` during setup.
      *  {bytes} setupData - The calldata for the setup `DELEGATECALL`.
      *  {address} fallbackHandler - The fallback handler to initialize the Safe with.
-     * @custom:computed-as keccak256("SafeInit(address singleton,address signerFactory,uint256 signerX,uint256 signerY,address signerVerifier,address setupTo,bytes setupData,address fallbackHandler)")
+     * @custom:computed-as keccak256("SafeInit(address singleton,address signerFactory,uint256 signerX,uint256 signerY,uint192 signerVerifiers,address setupTo,bytes setupData,address fallbackHandler)")
      */
-    bytes32 private constant SAFE_INIT_TYPEHASH = 0x7f7af906ef00923ea8f1b598abfc8ac66033c2807e9facdf52353f813dd7c747;
+    bytes32 private constant SAFE_INIT_TYPEHASH = 0xb8b5d6678d8c3ed815330874b6c0a30142f64104b7f6d1361d6775a7dbc5318b;
 
     /**
      * @notice The keccak256 hash of the EIP-712 SafeInitOp struct, representing the user operation to execute alongside initialization.
@@ -132,7 +132,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
      * @param signerFactory The custom ECDSA signer factory to use for creating an owner.
      * @param signerX The X coordinate of the signer's public key.
      * @param signerY The Y coordinate of the signer's public key.
-     * @param signerVerifier The address of the contract that verifies the signer's signature.
+     * @param signerVerifiers The address of the contract that verifies the signer's signature.
      * @param setupTo The contract to `DELEGATECALL` during setup.
      * @param setupData The calldata for the setup `DELEGATECALL`.
      * @param fallbackHandler The fallback handler to initialize the Safe with.
@@ -143,7 +143,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
         address signerFactory,
         uint256 signerX,
         uint256 signerY,
-        address signerVerifier,
+        P256.Verifiers signerVerifiers,
         address setupTo,
         bytes memory setupData,
         address fallbackHandler
@@ -160,7 +160,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
                         signerFactory,
                         signerX,
                         signerY,
-                        signerVerifier,
+                        signerVerifiers,
                         setupTo,
                         keccak256(setupData),
                         fallbackHandler
@@ -203,7 +203,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
         address signerFactory;
         uint256 signerX;
         uint256 signerY;
-        address signerVerifier;
+        P256.Verifiers signerVerifiers;
         {
             require(this.initializeThenUserOp.selector == bytes4(userOp.callData[:4]), "invalid user operation data");
 
@@ -211,16 +211,25 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
             address setupTo;
             bytes memory setupData;
             address fallbackHandler;
-            (singleton, signerFactory, signerX, signerY, signerVerifier, setupTo, setupData, fallbackHandler, ) = abi.decode(
+            (singleton, signerFactory, signerX, signerY, signerVerifiers, setupTo, setupData, fallbackHandler, ) = abi.decode(
                 userOp.callData[4:],
-                (address, address, uint256, uint256, address, address, bytes, address, bytes)
+                (address, address, uint256, uint256, P256.Verifiers, address, bytes, address, bytes)
             );
-            bytes32 initHash = getInitHash(singleton, signerFactory, signerX, signerY, signerVerifier, setupTo, setupData, fallbackHandler);
+            bytes32 initHash = getInitHash(
+                singleton,
+                signerFactory,
+                signerX,
+                signerY,
+                signerVerifiers,
+                setupTo,
+                setupData,
+                fallbackHandler
+            );
 
             require(initHash == _initHash(), "invalid init hash");
         }
 
-        validationData = _validateSignatures(userOp, userOpHash, signerFactory, signerX, signerY, signerVerifier);
+        validationData = _validateSignatures(userOp, userOpHash, signerFactory, signerX, signerY, signerVerifiers);
         if (missingAccountFunds > 0) {
             // solhint-disable-next-line no-inline-assembly
             assembly ("memory-safe") {
@@ -243,7 +252,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
      * @param signerFactory The custom ECDSA signer factory to use for creating an owner.
      * @param signerX The X coordinate of the signer's public key.
      * @param signerY The Y coordinate of the signer's public key.
-     * @param signerVerifier The address of the contract that verifies the signer's signature.
+     * @param signerVerifiers The address of the contract that verifies the signer's signature.
      * @param setupTo The contract to `DELEGATECALL` during setup.
      * @param setupData The calldata for the setup `DELEGATECALL`.
      * @param fallbackHandler The fallback handler to initialize the Safe with.
@@ -254,7 +263,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
         address signerFactory,
         uint256 signerX,
         uint256 signerY,
-        address signerVerifier,
+        P256.Verifiers signerVerifiers,
         address setupTo,
         bytes calldata setupData,
         address fallbackHandler,
@@ -263,7 +272,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
         SafeStorage.singleton = singleton;
         {
             address[] memory owners = new address[](1);
-            owners[0] = ICustomECDSASignerFactory(signerFactory).createSigner(signerX, signerY, signerVerifier);
+            owners[0] = ISafeSignerFactory(signerFactory).createSigner(signerX, signerY, signerVerifiers);
 
             ISafe(address(this)).setup(owners, 1, setupTo, setupData, fallbackHandler, address(0), 0, payable(address(0)));
         }
@@ -294,6 +303,11 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
      *  - `validUntil`: 6-byte timestamp value, or zero for "infinite". The user operation is valid only up to this time.
      *  - `validAfter`: 6-byte timestamp. The user operation is valid only after this time.
      * @param userOp User operation struct.
+     * @param userOpHash User operation hash.
+     * @param signerFactory The custom ECDSA signer factory to use for creating an owner.
+     * @param signerX The X coordinate of the signer's public key.
+     * @param signerY The Y coordinate of the signer's public key.
+     * @param signerVerifiers The address of the contract that verifies the signer's signature.
      * @return validationData An integer indicating the result of the validation.
      */
     function _validateSignatures(
@@ -302,7 +316,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
         address signerFactory,
         uint256 signerX,
         uint256 signerY,
-        address signerVerifier
+        P256.Verifiers signerVerifiers
     ) internal view returns (uint256 validationData) {
         uint48 validAfter;
         uint48 validUntil;
@@ -316,7 +330,7 @@ contract SafeECDSASignerLaunchpad is IAccount, SafeStorage {
 
         bytes32 operationHash = getOperationHash(userOpHash, validAfter, validUntil);
         try
-            ICustomECDSASignerFactory(signerFactory).isValidSignatureForSigner(operationHash, signature, signerX, signerY, signerVerifier)
+            ISafeSignerFactory(signerFactory).isValidSignatureForSigner(operationHash, signature, signerX, signerY, signerVerifiers)
         returns (bytes4 magicValue) {
             // The timestamps are validated by the entry point, therefore we will not check them again
             validationData = _packValidationData(magicValue != ERC1271.MAGIC_VALUE, validUntil, validAfter);

--- a/modules/passkey/contracts/SafeWebAuthnSigner.sol
+++ b/modules/passkey/contracts/SafeWebAuthnSigner.sol
@@ -2,8 +2,7 @@
 pragma solidity >=0.8.0;
 
 import {SignatureValidator} from "./base/SignatureValidator.sol";
-import {IP256Verifier} from "./interfaces/IP256Verifier.sol";
-import {WebAuthn} from "./libraries/WebAuthn.sol";
+import {P256, WebAuthn} from "./libraries/WebAuthn.sol";
 
 /**
  * @title WebAuthn Safe Signature Validator
@@ -22,27 +21,29 @@ contract SafeWebAuthnSigner is SignatureValidator {
     uint256 public immutable Y;
 
     /**
-     * @notice The P-256 verifier used for ECDSA signature validation.
+     * @notice The P-256 verifiers used for ECDSA signature validation.
      */
-    IP256Verifier public immutable VERIFIER;
+    P256.Verifiers public immutable VERIFIERS;
 
     /**
      * @dev Constructor function.
      * @param x The X coordinate of the P-256 public key of the WebAuthn credential.
      * @param y The Y coordinate of the P-256 public key of the WebAuthn credential.
-     * @param verifier The P-256 verifier to use for signature validation. It MUST implement the
-     * same interface as the EIP-7212 precompile.
+     * @param verifiers The P-256 verifiers to use for signature validation. This is the
+     * concatenation of `uint32(precompile) || address(fallback)` specifying the `precompile` to
+     * use as well as the `fallback` Solidity P-256 verifier implementation in case the precompile
+     * is not available.
      */
-    constructor(uint256 x, uint256 y, address verifier) {
+    constructor(uint256 x, uint256 y, P256.Verifiers verifiers) {
         X = x;
         Y = y;
-        VERIFIER = IP256Verifier(verifier);
+        VERIFIERS = verifiers;
     }
 
     /**
      * @inheritdoc SignatureValidator
      */
     function _verifySignature(bytes32 message, bytes calldata signature) internal view virtual override returns (bool success) {
-        success = WebAuthn.verifySignature(message, signature, WebAuthn.USER_VERIFICATION, X, Y, VERIFIER);
+        success = WebAuthn.verifySignature(message, signature, WebAuthn.USER_VERIFICATION, X, Y, VERIFIERS);
     }
 }

--- a/modules/passkey/contracts/interfaces/ISafeSignerFactory.sol
+++ b/modules/passkey/contracts/interfaces/ISafeSignerFactory.sol
@@ -1,23 +1,25 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0 <0.9.0;
 
+import {P256} from "../libraries/P256.sol";
+
 /**
- * @title Custom ECDSA Signer Factory
+ * @title Signer Factory for Custom P-256 Signing Schemes
  * @dev Interface for a factory contract that can create ERC-1271 compatible signers, and verify
- * signatures for custom ECDSA schemes.
+ * signatures for custom P-256 signing schemes.
  * @custom:security-contact bounty@safe.global
  */
-interface ICustomECDSASignerFactory {
+interface ISafeSignerFactory {
     /**
      * @notice Gets the unique signer address for the specified data.
      * @dev The unique signer address must be unique for some given data. The signer is not
      * guaranteed to be created yet.
      * @param x The x-coordinate of the public key.
      * @param y The y-coordinate of the public key.
-     * @param verifier The address of the verifier.
+     * @param verifiers The P-256 verifiers to use.
      * @return signer The signer address.
      */
-    function getSigner(uint256 x, uint256 y, address verifier) external view returns (address signer);
+    function getSigner(uint256 x, uint256 y, P256.Verifiers verifiers) external view returns (address signer);
 
     /**
      * @notice Create a new unique signer for the specified data.
@@ -25,10 +27,10 @@ interface ICustomECDSASignerFactory {
      * the unique owner already exists.
      * @param x The x-coordinate of the public key.
      * @param y The y-coordinate of the public key.
-     * @param verifier The address of the verifier.
+     * @param verifiers The P-256 verifiers to use.
      * @return signer The signer address.
      */
-    function createSigner(uint256 x, uint256 y, address verifier) external returns (address signer);
+    function createSigner(uint256 x, uint256 y, P256.Verifiers verifiers) external returns (address signer);
 
     /**
      * @notice Verifies a signature for the specified address without deploying it.
@@ -39,7 +41,7 @@ interface ICustomECDSASignerFactory {
      * @param signature The signature bytes.
      * @param x The x-coordinate of the public key.
      * @param y The y-coordinate of the public key.
-     * @param verifier The address of the verifier.
+     * @param verifiers The P-256 verifiers to use.
      * @return magicValue Returns the ERC-1271 magic value when the signature is valid. Reverting or
      * returning any other value implies an invalid signature.
      */
@@ -48,6 +50,6 @@ interface ICustomECDSASignerFactory {
         bytes calldata signature,
         uint256 x,
         uint256 y,
-        address verifier
+        P256.Verifiers verifiers
     ) external view returns (bytes4 magicValue);
 }

--- a/modules/passkey/contracts/libraries/P256.sol
+++ b/modules/passkey/contracts/libraries/P256.sol
@@ -155,6 +155,12 @@ library P256 {
         if (precompileVerifier != address(0)) {
             success = verifySignatureAllowMalleability(IP256Verifier(precompileVerifier), message, r, s, x, y);
         }
+
+        // If the precompile verification was not successful, fallback to a configured Solidity {IP256Verifier}
+        // implementation. Note that this means that invalid signatures are potentially checked twice, once with the
+        // precompile and once with the fallback verifier. This is intentional as there is no reliable way to
+        // distinguish between the precompile being unavailable and the signature being invalid, as in both cases the
+        // `STATICCALL` to the precompile contract will return empty bytes.
         if (!success && fallbackVerifier != address(0)) {
             success = verifySignatureAllowMalleability(IP256Verifier(fallbackVerifier), message, r, s, x, y);
         }

--- a/modules/passkey/contracts/libraries/P256.sol
+++ b/modules/passkey/contracts/libraries/P256.sol
@@ -18,6 +18,16 @@ library P256 {
     uint256 internal constant _N_DIV_2 = 57896044605178124381348723474703786764998477612067880171211129530534256022184;
 
     /**
+     * @notice P-256 precompile and fallback verifiers.
+     * @dev This is the packed `uint32(precompile) | uint160(fallback)` addresses to use for the
+     * verifiers. This allows both a precompile and a fallback Solidity implementation of the P-256
+     * curve to be specified. For networks where the P-256 precompile is planned to be enabled but
+     * not yet available, this allows for a verifier to seamlessly start using the precompile once
+     * it becomes available.
+     */
+    type Verifiers is uint192;
+
+    /**
      * @notice Verifies the signature of a message using the P256 elliptic curve with signature
      * malleability check.
      * @dev Note that a signature is valid for both `+s` and `-s`, making it trivial to, given a
@@ -48,6 +58,32 @@ library P256 {
         }
 
         success = verifySignatureAllowMalleability(verifier, message, r, s, x, y);
+    }
+
+    /**
+     * @notice Verifies the signature of a message using the P256 elliptic curve with signature
+     * malleability check.
+     * @param verifiers The P-256 verifiers to use.
+     * @param message The signed message.
+     * @param r The r component of the signature.
+     * @param s The s component of the signature.
+     * @param x The x coordinate of the public key.
+     * @param y The y coordinate of the public key.
+     * @return success A boolean indicating whether the signature is valid or not.
+     */
+    function verifySignature(
+        Verifiers verifiers,
+        bytes32 message,
+        uint256 r,
+        uint256 s,
+        uint256 x,
+        uint256 y
+    ) internal view returns (bool success) {
+        if (s > _N_DIV_2) {
+            return false;
+        }
+
+        success = verifySignatureAllowMalleability(verifiers, message, r, s, x, y);
     }
 
     /**
@@ -92,6 +128,35 @@ library P256 {
                 // Call does not revert
                 staticcall(gas(), verifier, input, 160, 0, 32)
             )
+        }
+    }
+
+    /**
+     * @notice Verifies the signature of a message using P256 elliptic curve, without signature
+     * malleability check.
+     * @param verifiers The P-256 verifiers to use.
+     * @param message The signed message.
+     * @param r The r component of the signature.
+     * @param s The s component of the signature.
+     * @param x The x coordinate of the public key.
+     * @param y The y coordinate of the public key.
+     * @return success A boolean indicating whether the signature is valid or not.
+     */
+    function verifySignatureAllowMalleability(
+        Verifiers verifiers,
+        bytes32 message,
+        uint256 r,
+        uint256 s,
+        uint256 x,
+        uint256 y
+    ) internal view returns (bool success) {
+        address precompileVerifier = address(uint160(uint256(Verifiers.unwrap(verifiers)) >> 160));
+        address fallbackVerifier = address(uint160(Verifiers.unwrap(verifiers)));
+        if (precompileVerifier != address(0)) {
+            success = verifySignatureAllowMalleability(IP256Verifier(precompileVerifier), message, r, s, x, y);
+        }
+        if (!success && fallbackVerifier != address(0)) {
+            success = verifySignatureAllowMalleability(IP256Verifier(fallbackVerifier), message, r, s, x, y);
         }
     }
 }

--- a/modules/passkey/contracts/libraries/WebAuthn.sol
+++ b/modules/passkey/contracts/libraries/WebAuthn.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import {IP256Verifier, P256} from "./P256.sol";
+import {P256} from "./P256.sol";
 
 /**
  * @title WebAuthn Signature Verification
@@ -10,7 +10,7 @@ import {IP256Verifier, P256} from "./P256.sol";
  * @custom:security-contact bounty@safe.global
  */
 library WebAuthn {
-    using P256 for IP256Verifier;
+    using P256 for P256.Verifiers;
 
     /**
      * @notice The WebAuthn signature data format.
@@ -245,7 +245,7 @@ library WebAuthn {
      * @param authenticatorFlags The authenticator data flags that must be set.
      * @param x The x-coordinate of the credential's public key.
      * @param y The y-coordinate of the credential's public key.
-     * @param verifier The P-256 verifier implementation to use.
+     * @param verifiers The P-256 verifier configuration to use.
      * @return success Whether the signature is valid.
      */
     function verifySignature(
@@ -254,9 +254,9 @@ library WebAuthn {
         AuthenticatorFlags authenticatorFlags,
         uint256 x,
         uint256 y,
-        IP256Verifier verifier
+        P256.Verifiers verifiers
     ) internal view returns (bool success) {
-        success = verifySignature(challenge, castSignature(signature), authenticatorFlags, x, y, verifier);
+        success = verifySignature(challenge, castSignature(signature), authenticatorFlags, x, y, verifiers);
     }
 
     /**
@@ -266,7 +266,7 @@ library WebAuthn {
      * @param authenticatorFlags The authenticator data flags that must be set.
      * @param x The x-coordinate of the credential's public key.
      * @param y The y-coordinate of the credential's public key.
-     * @param verifier The P-256 verifier implementation to use.
+     * @param verifiers The P-256 verifier configuration to use.
      * @return success Whether the signature is valid.
      */
     function verifySignature(
@@ -275,7 +275,7 @@ library WebAuthn {
         AuthenticatorFlags authenticatorFlags,
         uint256 x,
         uint256 y,
-        IP256Verifier verifier
+        P256.Verifiers verifiers
     ) internal view returns (bool success) {
         // The order of operations here is slightly counter-intuitive (in particular, you do not
         // need to encode the signing message if the expected authenticator flags are missing).
@@ -284,7 +284,7 @@ library WebAuthn {
 
         bytes memory message = encodeSigningMessage(challenge, signature.authenticatorData, signature.clientDataFields);
         if (checkAuthenticatorFlags(signature.authenticatorData, authenticatorFlags)) {
-            success = verifier.verifySignatureAllowMalleability(_sha256(message), signature.r, signature.s, x, y);
+            success = verifiers.verifySignatureAllowMalleability(_sha256(message), signature.r, signature.s, x, y);
         }
     }
 

--- a/modules/passkey/contracts/test/TestP256Lib.sol
+++ b/modules/passkey/contracts/test/TestP256Lib.sol
@@ -5,6 +5,7 @@ import {IP256Verifier, P256} from "../libraries/P256.sol";
 
 contract TestP256Lib {
     using P256 for IP256Verifier;
+    using P256 for P256.Verifiers;
 
     function verifySignature(
         IP256Verifier verifier,
@@ -26,5 +27,27 @@ contract TestP256Lib {
         uint256 y
     ) external view returns (bool success) {
         success = verifier.verifySignatureAllowMalleability(message, r, s, x, y);
+    }
+
+    function verifySignatureWithVerifiers(
+        P256.Verifiers verifiers,
+        bytes32 message,
+        uint256 r,
+        uint256 s,
+        uint256 x,
+        uint256 y
+    ) external view returns (bool success) {
+        success = verifiers.verifySignature(message, r, s, x, y);
+    }
+
+    function verifySignatureWithVerifiersAllowMalleability(
+        P256.Verifiers verifiers,
+        bytes32 message,
+        uint256 r,
+        uint256 s,
+        uint256 x,
+        uint256 y
+    ) external view returns (bool success) {
+        success = verifiers.verifySignatureAllowMalleability(message, r, s, x, y);
     }
 }

--- a/modules/passkey/contracts/test/TestWebAuthnLib.sol
+++ b/modules/passkey/contracts/test/TestWebAuthnLib.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import {WebAuthn} from "../libraries/WebAuthn.sol";
-import {IP256Verifier} from "../libraries/P256.sol";
+import {P256, WebAuthn} from "../libraries/WebAuthn.sol";
 
 contract TestWebAuthnLib {
     function encodeClientDataJson(
@@ -26,9 +25,9 @@ contract TestWebAuthnLib {
         WebAuthn.AuthenticatorFlags authenticatorFlags,
         uint256 x,
         uint256 y,
-        IP256Verifier verifier
+        P256.Verifiers verifiers
     ) external view returns (bool success) {
-        success = WebAuthn.verifySignature(challenge, signature, authenticatorFlags, x, y, verifier);
+        success = WebAuthn.verifySignature(challenge, signature, authenticatorFlags, x, y, verifiers);
     }
 
     function verifySignature(
@@ -37,8 +36,8 @@ contract TestWebAuthnLib {
         WebAuthn.AuthenticatorFlags authenticatorFlags,
         uint256 x,
         uint256 y,
-        IP256Verifier verifier
+        P256.Verifiers verifiers
     ) external view returns (bool success) {
-        success = WebAuthn.verifySignature(challenge, signature, authenticatorFlags, x, y, verifier);
+        success = WebAuthn.verifySignature(challenge, signature, authenticatorFlags, x, y, verifiers);
     }
 }

--- a/modules/passkey/contracts/test/TestWebAuthnSingletonSigner.sol
+++ b/modules/passkey/contracts/test/TestWebAuthnSingletonSigner.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import {SignatureValidator} from "../base/SignatureValidator.sol";
-import {WebAuthn, IP256Verifier} from "../libraries/WebAuthn.sol";
+import {P256, WebAuthn} from "../libraries/WebAuthn.sol";
 
 /**
  * @title WebAuthn Singleton Signer
@@ -10,13 +10,13 @@ import {WebAuthn, IP256Verifier} from "../libraries/WebAuthn.sol";
  */
 contract TestWebAuthnSingletonSigner is SignatureValidator {
     /**
-     * @notice Data associated with a WebAuthn signer. It reprensents the X and Y coordinates of the signer's public
-     * key. This is stored in a mapping using the account address as the key.
+     * @notice Data associated with a WebAuthn signer. It represents the X and Y coordinates of the
+     * signer's public key. This is stored in a mapping using the account address as the key.
      */
     struct OwnerData {
         uint256 x;
         uint256 y;
-        IP256Verifier verifier;
+        P256.Verifiers verifiers;
     }
 
     /**
@@ -47,7 +47,7 @@ contract TestWebAuthnSingletonSigner is SignatureValidator {
         OwnerData memory owner = owners[msg.sender];
 
         isValid =
-            address(owner.verifier) != address(0) &&
-            WebAuthn.verifySignature(message, signature, WebAuthn.USER_VERIFICATION, owner.x, owner.y, owner.verifier);
+            P256.Verifiers.unwrap(owner.verifiers) != 0 &&
+            WebAuthn.verifySignature(message, signature, WebAuthn.USER_VERIFICATION, owner.x, owner.y, owner.verifiers);
     }
 }

--- a/modules/passkey/src/deploy/launchpad.ts
+++ b/modules/passkey/src/deploy/launchpad.ts
@@ -8,7 +8,7 @@ const deploy: DeployFunction = async ({ deployments, getNamedAccounts }) => {
 
   const entryPoint = await deployments.getOrNull('EntryPoint').then((deployment) => deployment?.address ?? ENTRY_POINT)
 
-  await deploy('SafeECDSASignerLaunchpad', {
+  await deploy('SafeSignerLaunchpad', {
     from: deployer,
     args: [entryPoint],
     log: true,

--- a/modules/passkey/test/4337/WebAuthn.spec.ts
+++ b/modules/passkey/test/4337/WebAuthn.spec.ts
@@ -20,7 +20,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
       SafeProxyFactory,
       FCLP256Verifier,
       Safe4337Module,
-      SafeECDSASignerLaunchpad,
+      SafeSignerLaunchpad,
       EntryPoint,
       SafeWebAuthnSignerFactory,
     } = await deployments.fixture()
@@ -30,7 +30,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
     const module = await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)
     const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
-    const signerLaunchpad = await ethers.getContractAt('SafeECDSASignerLaunchpad', SafeECDSASignerLaunchpad.address)
+    const signerLaunchpad = await ethers.getContractAt('SafeSignerLaunchpad', SafeSignerLaunchpad.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
     const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
@@ -82,7 +82,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
         signerFactory: signerFactory.target,
         signerX: publicKey.x,
         signerY: publicKey.y,
-        signerVerifier: verifierAddress,
+        signerVerifiers: verifierAddress,
         setupTo: safeModuleSetup.target,
         setupData: safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]]),
         fallbackHandler: module.target,
@@ -95,7 +95,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
             { type: 'address', name: 'signerFactory' },
             { type: 'uint256', name: 'signerX' },
             { type: 'uint256', name: 'signerY' },
-            { type: 'address', name: 'signerVerifier' },
+            { type: 'uint192', name: 'signerVerifiers' },
             { type: 'address', name: 'setupTo' },
             { type: 'bytes', name: 'setupData' },
             { type: 'address', name: 'fallbackHandler' },
@@ -110,7 +110,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
           safeInit.signerFactory,
           safeInit.signerX,
           safeInit.signerY,
-          safeInit.signerVerifier,
+          safeInit.signerVerifiers,
           safeInit.setupTo,
           safeInit.setupData,
           safeInit.fallbackHandler,
@@ -140,7 +140,7 @@ describe('Safe4337Module - WebAuthn Owner', () => {
           safeInit.signerFactory,
           safeInit.signerX,
           safeInit.signerY,
-          safeInit.signerVerifier,
+          safeInit.signerVerifiers,
           safeInit.setupTo,
           safeInit.setupData,
           safeInit.fallbackHandler,

--- a/modules/passkey/test/4337/WebAuthnSigner.spec.ts
+++ b/modules/passkey/test/4337/WebAuthnSigner.spec.ts
@@ -16,7 +16,7 @@ describe('WebAuthn Signers [@4337]', () => {
     const {
       EntryPoint,
       Safe4337Module,
-      SafeECDSASignerLaunchpad,
+      SafeSignerLaunchpad,
       SafeProxyFactory,
       SafeModuleSetup,
       SafeL2,
@@ -30,7 +30,7 @@ describe('WebAuthn Signers [@4337]', () => {
     const module = await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)
     const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
     const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
-    const signerLaunchpad = await ethers.getContractAt('SafeECDSASignerLaunchpad', SafeECDSASignerLaunchpad.address)
+    const signerLaunchpad = await ethers.getContractAt('SafeSignerLaunchpad', SafeSignerLaunchpad.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
     const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
@@ -97,7 +97,7 @@ describe('WebAuthn Signers [@4337]', () => {
       signerFactory: signerFactory.target,
       signerX: publicKey.x,
       signerY: publicKey.y,
-      signerVerifier: verifierAddress,
+      signerVerifiers: verifierAddress,
       setupTo: safeModuleSetup.target,
       setupData: safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]]),
       fallbackHandler: module.target,
@@ -110,7 +110,7 @@ describe('WebAuthn Signers [@4337]', () => {
           { type: 'address', name: 'signerFactory' },
           { type: 'uint256', name: 'signerX' },
           { type: 'uint256', name: 'signerY' },
-          { type: 'address', name: 'signerVerifier' },
+          { type: 'uint192', name: 'signerVerifiers' },
           { type: 'address', name: 'setupTo' },
           { type: 'bytes', name: 'setupData' },
           { type: 'address', name: 'fallbackHandler' },
@@ -125,7 +125,7 @@ describe('WebAuthn Signers [@4337]', () => {
         safeInit.signerFactory,
         safeInit.signerX,
         safeInit.signerY,
-        safeInit.signerVerifier,
+        safeInit.signerVerifiers,
         safeInit.setupTo,
         safeInit.setupData,
         safeInit.fallbackHandler,
@@ -155,7 +155,7 @@ describe('WebAuthn Signers [@4337]', () => {
         safeInit.signerFactory,
         safeInit.signerX,
         safeInit.signerY,
-        safeInit.signerVerifier,
+        safeInit.signerVerifiers,
         safeInit.setupTo,
         safeInit.setupData,
         safeInit.fallbackHandler,

--- a/modules/passkey/test/4337/WebAuthnSingletonSigner.spec.ts
+++ b/modules/passkey/test/4337/WebAuthnSingletonSigner.spec.ts
@@ -110,7 +110,7 @@ describe('WebAuthn Singleton Signers [@4337]', () => {
           {
             op: 0 as const,
             to: signer.target,
-            data: signer.interface.encodeFunctionData('setOwner', [{ ...publicKey, verifier: verifier.target }]),
+            data: signer.interface.encodeFunctionData('setOwner', [{ ...publicKey, verifiers: verifier.target }]),
           },
         ]),
       ]),
@@ -167,7 +167,7 @@ describe('WebAuthn Singleton Signers [@4337]', () => {
     await user.sendTransaction({ to: safeAddress, value: ethers.parseEther('0.5') }).then((tx) => tx.wait())
 
     expect(ethers.dataLength(await ethers.provider.getCode(safeAddress))).to.equal(0)
-    expect(await signer.getOwner(safeAddress)).to.deep.equal([0n, 0n, ethers.ZeroAddress])
+    expect(await signer.getOwner(safeAddress)).to.deep.equal([0n, 0n, 0n])
 
     await bundler.sendUserOperation(userOp, await entryPoint.getAddress())
     await waitForUserOp(userOp)

--- a/modules/passkey/test/GasBenchmarking.spec.ts
+++ b/modules/passkey/test/GasBenchmarking.spec.ts
@@ -75,7 +75,7 @@ describe('Gas Benchmarking [@bench]', function () {
         })
 
         const { x, y } = decodePublicKey(credential.response)
-        const verifier = verifiers[key]
+        const verifier = await verifiers[key].getAddress()
 
         await factory.createSigner(x, y, verifier)
         const signer = await ethers.getContractAt('SafeWebAuthnSigner', await factory.getSigner(x, y, verifier))

--- a/modules/passkey/test/SafeWebAuthnSigner.spec.ts
+++ b/modules/passkey/test/SafeWebAuthnSigner.spec.ts
@@ -1,3 +1,4 @@
+import { setCode } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 
@@ -11,19 +12,23 @@ describe('SafeWebAuthnSigner', () => {
     const y = ethers.id('publicKey.y')
     const MockContract = await ethers.getContractFactory('MockContract')
     const mockVerifier = await MockContract.deploy()
+    const precompileAddress = `0x${'00'.repeat(18)}0100`
+    const mockPrecompile = await ethers.getContractAt('MockContract', precompileAddress)
+    await setCode(precompileAddress, await ethers.provider.getCode(mockVerifier))
     const SafeWebAuthnSigner = await ethers.getContractFactory('SafeWebAuthnSigner')
-    const signer = await SafeWebAuthnSigner.deploy(x, y, mockVerifier)
+    const verifiers = BigInt(ethers.solidityPacked(['uint32', 'address'], [Number(precompileAddress), mockVerifier.target]))
+    const signer = await SafeWebAuthnSigner.deploy(x, y, verifiers)
 
-    return { x, y, mockVerifier, signer }
+    return { x, y, mockPrecompile, mockVerifier, verifiers, signer }
   })
 
   describe('constructor', function () {
     it('Should set immutables', async () => {
-      const { x, y, mockVerifier, signer } = await setupTests()
+      const { x, y, verifiers, signer } = await setupTests()
 
       expect(await signer.X()).to.equal(x)
       expect(await signer.Y()).to.equal(y)
-      expect(await signer.VERIFIER()).to.equal(mockVerifier.target)
+      expect(await signer.VERIFIERS()).to.equal(verifiers)
     })
   })
 
@@ -51,6 +56,40 @@ describe('SafeWebAuthnSigner', () => {
       })
 
       await mockVerifier.givenCalldataReturnBool(
+        ethers.solidityPacked(
+          ['bytes32', 'uint256', 'uint256', 'uint256', 'uint256'],
+          [ethers.sha256(encodeWebAuthnSigningMessage(clientData, DUMMY_AUTHENTICATOR_DATA)), r, s, x, y],
+        ),
+        true,
+      )
+
+      expect(await signer['isValidSignature(bytes32,bytes)'](dataHash, signature)).to.equal(ERC1271.MAGIC_VALUE)
+      expect(await signer['isValidSignature(bytes,bytes)'](data, signature)).to.equal(ERC1271.LEGACY_MAGIC_VALUE)
+    })
+
+    it('Should return true when the precompile returns true', async () => {
+      const { x, y, mockPrecompile, signer } = await setupTests()
+
+      const data = ethers.toUtf8Bytes('some data to sign')
+      const dataHash = ethers.keccak256(data)
+
+      const clientData = {
+        type: 'webauthn.get' as const,
+        challenge: base64UrlEncode(dataHash),
+        origin: 'https://safe.global',
+      }
+
+      const r = BigInt(ethers.id('signature.r'))
+      const s = BigInt(ethers.id('signature.s'))
+
+      const signature = getSignatureBytes({
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: '"origin":"https://safe.global"',
+        r,
+        s,
+      })
+
+      await mockPrecompile.givenCalldataReturnBool(
         ethers.solidityPacked(
           ['bytes32', 'uint256', 'uint256', 'uint256', 'uint256'],
           [ethers.sha256(encodeWebAuthnSigningMessage(clientData, DUMMY_AUTHENTICATOR_DATA)), r, s, x, y],

--- a/modules/passkey/test/SafeWebAuthnSignerFactory.spec.ts
+++ b/modules/passkey/test/SafeWebAuthnSignerFactory.spec.ts
@@ -48,7 +48,7 @@ describe('SafeWebAuthnSignerFactory', () => {
       for (const params of [
         [ethers.id('publicKey.otherX'), y, verifiers],
         [x, ethers.id('publicKey.otherY'), verifiers],
-        [x, y, '0xfefefefefefefefefefefefefefefefefefefefe'],
+        [x, y, `0x${'fe'.repeat(20)}`],
       ] as const) {
         expect(await factory.getSigner(...params)).to.not.equal(signer)
       }

--- a/modules/passkey/test/SafeWebAuthnSignerFactory.spec.ts
+++ b/modules/passkey/test/SafeWebAuthnSignerFactory.spec.ts
@@ -1,3 +1,4 @@
+import { setCode } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
 
@@ -12,38 +13,42 @@ describe('SafeWebAuthnSignerFactory', () => {
 
     const MockContract = await ethers.getContractFactory('MockContract')
     const mockVerifier = await MockContract.deploy()
+    const precompileAddress = `0x${'00'.repeat(18)}0100`
+    const mockPrecompile = await ethers.getContractAt('MockContract', precompileAddress)
+    await setCode(precompileAddress, await ethers.provider.getCode(mockVerifier))
+    const verifiers = BigInt(ethers.solidityPacked(['uint32', 'uint160'], [mockPrecompile.target, mockVerifier.target]))
 
-    return { factory, mockVerifier }
+    return { factory, mockPrecompile, mockVerifier, verifiers }
   })
 
   describe('getSigner', function () {
     it('Should return the address that a signer will be created on', async () => {
-      const { factory, mockVerifier } = await setupTests()
+      const { factory, verifiers } = await setupTests()
 
       const x = ethers.id('publicKey.x')
       const y = ethers.id('publicKey.y')
 
-      const signer = await factory.getSigner(x, y, mockVerifier)
+      const signer = await factory.getSigner(x, y, verifiers)
 
       expect(ethers.dataLength(await ethers.provider.getCode(signer))).to.equal(0)
 
-      await factory.createSigner(x, y, mockVerifier)
+      await factory.createSigner(x, y, verifiers)
 
       expect(ethers.dataLength(await ethers.provider.getCode(signer))).to.not.equal(0)
     })
 
     it('Should return different signer for different inputs', async () => {
-      const { factory, mockVerifier } = await setupTests()
+      const { factory, verifiers } = await setupTests()
 
       const x = ethers.id('publicKey.x')
       const y = ethers.id('publicKey.y')
 
-      const signer = await factory.getSigner(x, y, mockVerifier)
+      const signer = await factory.getSigner(x, y, verifiers)
 
       for (const params of [
-        [ethers.id('publicKey.otherX'), y, mockVerifier],
-        [x, ethers.id('publicKey.otherY'), mockVerifier],
-        [x, y, '0x0000000000000000000000000000000000000100'],
+        [ethers.id('publicKey.otherX'), y, verifiers],
+        [x, ethers.id('publicKey.otherY'), verifiers],
+        [x, y, '0xfefefefefefefefefefefefefefefefefefefefe'],
       ] as const) {
         expect(await factory.getSigner(...params)).to.not.equal(signer)
       }
@@ -52,41 +57,75 @@ describe('SafeWebAuthnSignerFactory', () => {
 
   describe('createSigner', function () {
     it('Should create a signer and return its deterministic address', async () => {
-      const { factory, mockVerifier } = await setupTests()
+      const { factory, verifiers } = await setupTests()
 
       const x = ethers.id('publicKey.x')
       const y = ethers.id('publicKey.y')
 
-      const signer = await factory.createSigner.staticCall(x, y, mockVerifier)
+      const signer = await factory.createSigner.staticCall(x, y, verifiers)
 
       const SafeWebAuthnSigner = await ethers.getContractFactory('SafeWebAuthnSigner')
-      const { data: initCode } = await SafeWebAuthnSigner.getDeployTransaction(x, y, mockVerifier)
+      const { data: initCode } = await SafeWebAuthnSigner.getDeployTransaction(x, y, verifiers)
       expect(signer).to.equal(ethers.getCreate2Address(await factory.getAddress(), ethers.ZeroHash, ethers.keccak256(initCode)))
 
       expect(ethers.dataLength(await ethers.provider.getCode(signer))).to.equal(0)
 
-      await factory.createSigner(x, y, mockVerifier)
+      await factory.createSigner(x, y, verifiers)
 
       expect(ethers.dataLength(await ethers.provider.getCode(signer))).to.not.equal(0)
     })
 
     it('Should be idempotent', async () => {
-      const { factory, mockVerifier } = await setupTests()
+      const { factory, verifiers } = await setupTests()
 
       const x = ethers.id('publicKey.x')
       const y = ethers.id('publicKey.y')
 
-      const signer = await factory.createSigner.staticCall(x, y, mockVerifier)
+      const signer = await factory.createSigner.staticCall(x, y, verifiers)
 
-      await factory.createSigner(x, y, mockVerifier)
+      await factory.createSigner(x, y, verifiers)
 
-      expect(await factory.createSigner.staticCall(x, y, mockVerifier)).to.eq(signer)
-      await expect(factory.createSigner(x, y, mockVerifier)).to.not.be.reverted
+      expect(await factory.createSigner.staticCall(x, y, verifiers)).to.eq(signer)
+      await expect(factory.createSigner(x, y, verifiers)).to.not.be.reverted
     })
   })
 
   describe('isValidSignatureForSigner', function () {
     it('Should return true when the verifier returns true', async () => {
+      const { factory, mockPrecompile, mockVerifier, verifiers } = await setupTests()
+
+      const dataHash = ethers.id('some data to sign')
+      const clientData = {
+        type: 'webauthn.get' as const,
+        challenge: base64UrlEncode(dataHash),
+        origin: 'https://safe.global',
+      }
+
+      const r = BigInt(ethers.id('signature.r'))
+      const s = BigInt(ethers.id('signature.s'))
+      const x = ethers.id('publicKey.x')
+      const y = ethers.id('publicKey.y')
+
+      const signature = getSignatureBytes({
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: '"origin":"https://safe.global"',
+        r,
+        s,
+      })
+
+      await mockPrecompile.givenAnyReturnBool(false)
+      await mockVerifier.givenCalldataReturnBool(
+        ethers.solidityPacked(
+          ['bytes32', 'uint256', 'uint256', 'uint256', 'uint256'],
+          [ethers.sha256(encodeWebAuthnSigningMessage(clientData, DUMMY_AUTHENTICATOR_DATA)), r, s, x, y],
+        ),
+        true,
+      )
+
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, verifiers)).to.equal(ERC1271.MAGIC_VALUE)
+    })
+
+    it('Should return true when the verifier without precompile returns true', async () => {
       const { factory, mockVerifier } = await setupTests()
 
       const dataHash = ethers.id('some data to sign')
@@ -116,11 +155,44 @@ describe('SafeWebAuthnSignerFactory', () => {
         true,
       )
 
-      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.equal(ERC1271.MAGIC_VALUE)
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier.target)).to.equal(ERC1271.MAGIC_VALUE)
+    })
+
+    it('Should return true when the precompile returns true', async () => {
+      const { factory, mockPrecompile, verifiers } = await setupTests()
+
+      const dataHash = ethers.id('some data to sign')
+      const clientData = {
+        type: 'webauthn.get' as const,
+        challenge: base64UrlEncode(dataHash),
+        origin: 'https://safe.global',
+      }
+
+      const r = BigInt(ethers.id('signature.r'))
+      const s = BigInt(ethers.id('signature.s'))
+      const x = ethers.id('publicKey.x')
+      const y = ethers.id('publicKey.y')
+
+      const signature = getSignatureBytes({
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: '"origin":"https://safe.global"',
+        r,
+        s,
+      })
+
+      await mockPrecompile.givenCalldataReturnBool(
+        ethers.solidityPacked(
+          ['bytes32', 'uint256', 'uint256', 'uint256', 'uint256'],
+          [ethers.sha256(encodeWebAuthnSigningMessage(clientData, DUMMY_AUTHENTICATOR_DATA)), r, s, x, y],
+        ),
+        true,
+      )
+
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, verifiers)).to.equal(ERC1271.MAGIC_VALUE)
     })
 
     it('Should return false when the verifier does not return true', async () => {
-      const { factory, mockVerifier } = await setupTests()
+      const { factory, mockVerifier, verifiers } = await setupTests()
 
       const dataHash = ethers.id('some data to sign')
       const clientData = {
@@ -150,11 +222,11 @@ describe('SafeWebAuthnSignerFactory', () => {
         '0xfe',
       )
 
-      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.not.equal(ERC1271.MAGIC_VALUE)
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, verifiers)).to.not.equal(ERC1271.MAGIC_VALUE)
     })
 
     it('Should return false on non-matching authenticator flags', async () => {
-      const { factory, mockVerifier } = await setupTests()
+      const { factory, mockPrecompile, mockVerifier, verifiers } = await setupTests()
 
       const dataHash = ethers.id('some data to sign')
       const authenticatorData = ethers.getBytes(
@@ -180,8 +252,9 @@ describe('SafeWebAuthnSignerFactory', () => {
         s,
       })
 
+      await mockPrecompile.givenAnyReturnBool(true)
       await mockVerifier.givenAnyReturnBool(true)
-      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier)).to.not.equal(ERC1271.MAGIC_VALUE)
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, verifiers)).to.not.equal(ERC1271.MAGIC_VALUE)
     })
   })
 })

--- a/modules/passkey/test/libraries/P256.spec.ts
+++ b/modules/passkey/test/libraries/P256.spec.ts
@@ -1,4 +1,6 @@
+import { setCode } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { expect } from 'chai'
+import { Contract } from 'ethers'
 import { deployments, ethers } from 'hardhat'
 
 import { Account } from '../utils/p256'
@@ -9,62 +11,173 @@ describe('P256', function () {
 
     const verifier = await ethers.getContractAt('FCLP256Verifier', FCLP256Verifier.address)
 
+    const precompileAddress = ethers.toBeHex(0x0100, 20)
+    await setCode(precompileAddress, await ethers.provider.getCode(verifier))
+    const precompile = await ethers.getContractAt('IP256Verifier', precompileAddress)
+
+    const verifiers = BigInt(ethers.solidityPacked(['uint32', 'address'], [precompileAddress, FCLP256Verifier.address]))
+    const allVerifiers = [
+      [precompileAddress, FCLP256Verifier.address],
+      [ethers.ZeroAddress, FCLP256Verifier.address],
+      [precompileAddress, ethers.ZeroAddress],
+      [ethers.ZeroAddress, precompileAddress],
+    ].map(([precompile, fallback]) => BigInt(ethers.solidityPacked(['uint32', 'address'], [precompile, fallback])))
+
     const P256Lib = await ethers.getContractFactory('TestP256Lib')
     const p256Lib = await P256Lib.deploy()
 
     const account = new Account()
 
-    return { verifier, p256Lib, account }
+    return { precompile, verifier, verifiers, allVerifiers, p256Lib, account }
   })
 
-  it('Should return true on valid signature', async function () {
-    const { verifier, p256Lib, account } = await setupTests()
+  describe('isValidSignature', function () {
+    it('Should return true on valid signature', async function () {
+      const { verifier, p256Lib, account } = await setupTests()
 
-    const message = ethers.id('hello passkeys')
-    const { r, s } = account.sign(message)
-    const { x, y } = account.publicKey
+      const message = ethers.id('hello passkeys')
+      const { r, s } = account.sign(message)
+      const { x, y } = account.publicKey
 
-    expect(await p256Lib.verifySignature(verifier, message, r, s, x, y)).to.be.true
+      expect(await p256Lib.verifySignature(verifier, message, r, s, x, y)).to.be.true
+      expect(await p256Lib.verifySignatureAllowMalleability(verifier, message, r, s, x, y)).to.be.true
+    })
+
+    it('Should return false on invalid signature', async function () {
+      const { verifier, p256Lib } = await setupTests()
+
+      expect(await p256Lib.verifySignature(verifier, ethers.ZeroHash, 1, 2, 3, 4)).to.be.false
+      expect(await p256Lib.verifySignatureAllowMalleability(verifier, ethers.ZeroHash, 1, 2, 3, 4)).to.be.false
+    })
+
+    it('Should check for signature signature malleability', async function () {
+      const { verifier, p256Lib, account } = await setupTests()
+
+      const message = ethers.id('hello passkeys')
+      const { r, highS } = account.sign(message)
+      const { x, y } = account.publicKey
+
+      expect(await p256Lib.verifySignature(verifier, message, r, highS, x, y)).to.be.false
+      expect(await p256Lib.verifySignatureAllowMalleability(verifier, message, r, highS, x, y)).to.be.true
+    })
+
+    it('Should return false for misbehaving verifiers', async function () {
+      const { p256Lib, account } = await setupTests()
+
+      const message = ethers.id('hello passkeys')
+      const { r, s } = account.sign(message)
+      const { x, y } = account.publicKey
+
+      const MockContract = await ethers.getContractFactory('MockContract')
+      const mockVerifier = await MockContract.deploy()
+
+      for (const configureMock of [
+        // wrong return data length
+        () => mockVerifier.givenAnyReturn(ethers.AbiCoder.defaultAbiCoder().encode(['bool', 'uint256'], [true, 42])),
+        // invalid boolean value
+        () => mockVerifier.givenAnyReturnUint(ethers.MaxUint256),
+        // revert
+        () => mockVerifier.givenAnyRevert(),
+      ]) {
+        await configureMock()
+        expect(await p256Lib.verifySignature(mockVerifier, message, r, s, x, y)).to.be.false
+        expect(await p256Lib.verifySignatureAllowMalleability(mockVerifier, message, r, s, x, y)).to.be.false
+      }
+    })
   })
 
-  it('Should return false on invalid signature', async function () {
-    const { verifier, p256Lib } = await setupTests()
+  describe('isValidSignatureWithVerifiers', function () {
+    it('Should handle all possible verifier configurations', async function () {
+      const { allVerifiers, p256Lib, account } = await setupTests()
 
-    expect(await p256Lib.verifySignature(verifier, ethers.ZeroHash, 1, 2, 3, 4)).to.be.false
-  })
+      const message = ethers.id('hello passkeys')
+      const { r, s } = account.sign(message)
+      const { x, y } = account.publicKey
 
-  it('Should check for signature signature malleability', async function () {
-    const { verifier, p256Lib, account } = await setupTests()
+      for (const verifiers of allVerifiers) {
+        expect(await p256Lib.verifySignatureWithVerifiers(verifiers, message, r, s, x, y)).to.be.true
+        expect(await p256Lib.verifySignatureWithVerifiersAllowMalleability(verifiers, message, r, s, x, y)).to.be.true
+      }
+    })
 
-    const message = ethers.id('hello passkeys')
-    const { r, highS } = account.sign(message)
-    const { x, y } = account.publicKey
+    it('Should fallback to Solidity verifier when precompile fails', async function () {
+      const { precompile, verifiers, p256Lib, account } = await setupTests()
 
-    expect(await p256Lib.verifySignature(verifier, message, r, highS, x, y)).to.be.false
-    expect(await p256Lib.verifySignatureAllowMalleability(verifier, message, r, highS, x, y)).to.be.true
-  })
+      const message = ethers.id('hello passkeys')
+      const { r, s } = account.sign(message)
+      const { x, y } = account.publicKey
 
-  it('Should return false for misbehaving verifiers', async function () {
-    const { p256Lib, account } = await setupTests()
+      const MockContract = await ethers.getContractFactory('MockContract')
+      const mock = await MockContract.deploy()
+      await setCode(await precompile.getAddress(), await ethers.provider.getCode(mock))
+      const mockPrecompile = await ethers.getContractAt('MockContract', precompile)
 
-    const message = ethers.id('hello passkeys')
-    const { r, s } = account.sign(message)
-    const { x, y } = account.publicKey
+      for (const configureMock of [
+        // wrong return data length
+        () => mockPrecompile.givenAnyReturn(ethers.AbiCoder.defaultAbiCoder().encode(['bool', 'uint256'], [true, 42])),
+        // invalid boolean value
+        () => mockPrecompile.givenAnyReturnUint(ethers.MaxUint256),
+        // revert
+        () => mockPrecompile.givenAnyRevert(),
+      ]) {
+        await configureMock()
+        expect(await p256Lib.verifySignatureWithVerifiers(verifiers, message, r, s, x, y)).to.be.true
+        expect(await p256Lib.verifySignatureWithVerifiersAllowMalleability(verifiers, message, r, s, x, y)).to.be.true
+      }
+    })
 
-    const MockContract = await ethers.getContractFactory('MockContract')
-    const mockVerifier = await MockContract.deploy()
+    it('Should return false on invalid signature', async function () {
+      const { allVerifiers, p256Lib } = await setupTests()
 
-    for (const configureMock of [
-      // wrong return data length
-      () => mockVerifier.givenAnyReturn(ethers.AbiCoder.defaultAbiCoder().encode(['bool', 'uint256'], [true, 42])),
-      // invalid boolean value
-      () => mockVerifier.givenAnyReturnUint(ethers.MaxUint256),
-      // revert
-      () => mockVerifier.givenAnyRevert(),
-    ]) {
-      await configureMock()
-      expect(await p256Lib.verifySignature(mockVerifier, message, r, s, x, y)).to.be.false
-      expect(await p256Lib.verifySignatureAllowMalleability(mockVerifier, message, r, s, x, y)).to.be.false
-    }
+      for (const verifiers of allVerifiers) {
+        expect(await p256Lib.verifySignatureWithVerifiers(verifiers, ethers.ZeroHash, 1, 2, 3, 4)).to.be.false
+        expect(await p256Lib.verifySignatureWithVerifiersAllowMalleability(verifiers, ethers.ZeroHash, 1, 2, 3, 4)).to.be.false
+      }
+    })
+
+    it('Should check for signature signature malleability', async function () {
+      const { allVerifiers, p256Lib, account } = await setupTests()
+
+      const message = ethers.id('hello passkeys')
+      const { r, highS } = account.sign(message)
+      const { x, y } = account.publicKey
+
+      for (const verifiers of allVerifiers) {
+        expect(await p256Lib.verifySignatureWithVerifiers(verifiers, message, r, highS, x, y)).to.be.false
+        expect(await p256Lib.verifySignatureWithVerifiersAllowMalleability(verifiers, message, r, highS, x, y)).to.be.true
+      }
+    })
+
+    it('Should return false for misbehaving verifiers', async function () {
+      const { precompile, p256Lib, account } = await setupTests()
+
+      const message = ethers.id('hello passkeys')
+      const { r, s } = account.sign(message)
+      const { x, y } = account.publicKey
+
+      const MockContract = await ethers.getContractFactory('MockContract')
+      const mockVerifier = await MockContract.deploy()
+      await setCode(await precompile.getAddress(), await ethers.provider.getCode(mockVerifier))
+      const mockPrecompile = await ethers.getContractAt('MockContract', precompile)
+
+      const verifiers = BigInt(ethers.solidityPacked(['uint32', 'address'], [mockPrecompile.target, mockVerifier.target]))
+
+      const configurations = [
+        // wrong return data length
+        (m: Contract) => m.givenAnyReturn(ethers.AbiCoder.defaultAbiCoder().encode(['bool', 'uint256'], [true, 42])),
+        // invalid boolean value
+        (m: Contract) => m.givenAnyReturnUint(ethers.MaxUint256),
+        // revert
+        (m: Contract) => m.givenAnyRevert(),
+      ]
+      for (const configurePrecompile of configurations) {
+        for (const configureVerifier of configurations) {
+          await configurePrecompile(mockPrecompile)
+          await configureVerifier(mockVerifier)
+          expect(await p256Lib.verifySignatureWithVerifiers(verifiers, message, r, s, x, y)).to.be.false
+          expect(await p256Lib.verifySignatureWithVerifiersAllowMalleability(verifiers, message, r, s, x, y)).to.be.false
+        }
+      }
+    })
   })
 })


### PR DESCRIPTION
This PR changes the internal workings of the signers to accept a uint192 instead of an address as the `verifier` (well, now `verifiers`) parameter. This allows a signer to encode BOTH a precompile address as well as a Solidity implementation fallback for the P-256 curve.

Additionally, this required changing the interface of the `ICustomECDSASignerFactory`. It is now very much tied to the P-256 implementation that we have, and as such I renamed things to just `ISafeSignerFactory` and `SafeSignerLaunchpad`, since it is not a general ECDSA solution, but one that is particular to the P-256 implementation that we have and in particular supporting P-256 precompile with Solidity fallback.

The PR changes **a lot** of files, but this is mostly small modifications to tests. Unfortunately, I don't really see a way around this without pushing a PR with a broken test suite which I did not want to do.

Overall, I think this is definitely a nice feature to have - as it adds a small overhead on top of the regular verification but allows accounts to seamlessly start using precompile on networks that don't have it available yet.
