### PR TITLE
Passkey package: Add typechain types to the typescript build, fix types

### DIFF
--- a/modules/passkey/test/4337/WebAuthnSingletonSigner.spec.ts
+++ b/modules/passkey/test/4337/WebAuthnSingletonSigner.spec.ts
@@ -78,6 +78,7 @@ describe('WebAuthn Singleton Signers [@4337]', () => {
       signer,
       navigator,
     } = await setupTests()
+    const verifierAddress = await verifier.getAddress()
 
     const credential = navigator.credentials.create({
       publicKey: {
@@ -110,7 +111,7 @@ describe('WebAuthn Singleton Signers [@4337]', () => {
           {
             op: 0 as const,
             to: signer.target,
-            data: signer.interface.encodeFunctionData('setOwner', [{ ...publicKey, verifiers: verifier.target }]),
+            data: signer.interface.encodeFunctionData('setOwner', [{ ...publicKey, verifiers: verifierAddress }]),
           },
         ]),
       ]),

--- a/modules/passkey/test/SafeWebAuthnSignerFactory.spec.ts
+++ b/modules/passkey/test/SafeWebAuthnSignerFactory.spec.ts
@@ -127,6 +127,7 @@ describe('SafeWebAuthnSignerFactory', () => {
 
     it('Should return true when the verifier without precompile returns true', async () => {
       const { factory, mockVerifier } = await setupTests()
+      const mockVerifierAddress = await mockVerifier.getAddress()
 
       const dataHash = ethers.id('some data to sign')
       const clientData = {
@@ -155,7 +156,7 @@ describe('SafeWebAuthnSignerFactory', () => {
         true,
       )
 
-      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifier.target)).to.equal(ERC1271.MAGIC_VALUE)
+      expect(await factory.isValidSignatureForSigner(dataHash, signature, x, y, mockVerifierAddress)).to.equal(ERC1271.MAGIC_VALUE)
     })
 
     it('Should return true when the precompile returns true', async () => {

--- a/modules/passkey/test/libraries/P256.spec.ts
+++ b/modules/passkey/test/libraries/P256.spec.ts
@@ -1,9 +1,9 @@
 import { setCode } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { expect } from 'chai'
-import { Contract } from 'ethers'
 import { deployments, ethers } from 'hardhat'
 
 import { Account } from '../utils/p256'
+import { MockContract } from '../../typechain-types'
 
 describe('P256', function () {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
@@ -164,11 +164,11 @@ describe('P256', function () {
 
       const configurations = [
         // wrong return data length
-        (m: Contract) => m.givenAnyReturn(ethers.AbiCoder.defaultAbiCoder().encode(['bool', 'uint256'], [true, 42])),
+        (m: MockContract) => m.givenAnyReturn(ethers.AbiCoder.defaultAbiCoder().encode(['bool', 'uint256'], [true, 42])),
         // invalid boolean value
-        (m: Contract) => m.givenAnyReturnUint(ethers.MaxUint256),
+        (m: MockContract) => m.givenAnyReturnUint(ethers.MaxUint256),
         // revert
-        (m: Contract) => m.givenAnyRevert(),
+        (m: MockContract) => m.givenAnyRevert(),
       ]
       for (const configurePrecompile of configurations) {
         for (const configureVerifier of configurations) {

--- a/modules/passkey/test/libraries/WebAuthn.spec.ts
+++ b/modules/passkey/test/libraries/WebAuthn.spec.ts
@@ -25,9 +25,9 @@ describe('WebAuthn Library', () => {
 
       for (let i = 0; i < 50; i++) {
         const challenge = ethers.hexlify(ethers.randomBytes(32))
-        const cliengtData = JSON.parse(await webAuthnLib.encodeClientDataJson(challenge, DUMMY_CLIENT_DATA_FIELDS))
+        const clientData = JSON.parse(await webAuthnLib.encodeClientDataJson(challenge, DUMMY_CLIENT_DATA_FIELDS))
 
-        expect(cliengtData.challenge).to.be.equal(base64.encodeFromHex(challenge))
+        expect(clientData.challenge).to.be.equal(base64.encodeFromHex(challenge))
       }
     })
   })
@@ -56,6 +56,7 @@ describe('WebAuthn Library', () => {
   describe('verifySignature', function () {
     it('Should return false when the verifier returns false', async () => {
       const { webAuthnLib, mockP256Verifier } = await setupTests()
+      const mockP256VerifierAddress = await mockP256Verifier.getAddress()
       await mockP256Verifier.givenAnyReturnBool(false)
 
       const authenticatorData = ethers.randomBytes(100)
@@ -71,13 +72,14 @@ describe('WebAuthn Library', () => {
       }
       const signatureBytes = getSignatureBytes(signature)
 
-      expect(await webAuthnLib.verifySignature(challenge, signature, '0x01', 0n, 0n, mockP256Verifier.target)).to.be.false
+      expect(await webAuthnLib.verifySignature(challenge, signature, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.false
 
-      expect(await webAuthnLib.verifySignatureCastSig(challenge, signatureBytes, '0x01', 0n, 0n, mockP256Verifier.target)).to.be.false
+      expect(await webAuthnLib.verifySignatureCastSig(challenge, signatureBytes, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.false
     })
 
     it('Should return false on non-matching authenticator flags', async () => {
       const { webAuthnLib, mockP256Verifier } = await setupTests()
+      const mockP256VerifierAddress = await mockP256Verifier.getAddress()
       // The authenticator check happens on the library level, so false is returned before the verifier is called
       await mockP256Verifier.givenAnyReturnBool(true)
 
@@ -94,13 +96,14 @@ describe('WebAuthn Library', () => {
       }
       const signatureBytes = getSignatureBytes(signature)
 
-      expect(await webAuthnLib.verifySignature(challenge, signature, '0x01', 0n, 0n, mockP256Verifier.target)).to.be.false
+      expect(await webAuthnLib.verifySignature(challenge, signature, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.false
 
-      expect(await webAuthnLib.verifySignatureCastSig(challenge, signatureBytes, '0x01', 0n, 0n, mockP256Verifier.target)).to.be.false
+      expect(await webAuthnLib.verifySignatureCastSig(challenge, signatureBytes, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.false
     })
 
     it('Should return true when the verifier returns true', async () => {
       const { webAuthnLib, mockP256Verifier } = await setupTests()
+      const mockP256VerifierAddress = await mockP256Verifier.getAddress()
       await mockP256Verifier.givenAnyReturnBool(true)
 
       const authenticatorData = ethers.randomBytes(100)
@@ -115,9 +118,9 @@ describe('WebAuthn Library', () => {
       }
       const signatureBytes = getSignatureBytes(signature)
 
-      expect(await webAuthnLib.verifySignature(challenge, signature, '0x01', 0n, 0n, mockP256Verifier.target)).to.be.true
+      expect(await webAuthnLib.verifySignature(challenge, signature, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.true
 
-      expect(await webAuthnLib.verifySignatureCastSig(challenge, signatureBytes, '0x01', 0n, 0n, mockP256Verifier.target)).to.be.true
+      expect(await webAuthnLib.verifySignatureCastSig(challenge, signatureBytes, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.true
     })
   })
 })

--- a/modules/passkey/test/userstories/RotatePasskeyOwner.spec.ts
+++ b/modules/passkey/test/userstories/RotatePasskeyOwner.spec.ts
@@ -9,7 +9,7 @@ import {
   signSafeOp,
 } from '@safe-global/safe-4337/dist/src/utils/userOp'
 import { buildSignatureBytes } from '@safe-global/safe-4337/dist/src/utils/execution'
-import { chainId } from '@safe-global/safe-4337/dist/test/utils/encoding'
+import { chainId } from '../utils/hardhat'
 
 /**
  * User story: Rotate passkey owner

--- a/modules/passkey/test/userstories/RotatePasskeyOwner.spec.ts
+++ b/modules/passkey/test/userstories/RotatePasskeyOwner.spec.ts
@@ -7,9 +7,9 @@ import {
   buildSafeUserOpTransaction,
   buildPackedUserOperationFromSafeUserOperation,
   signSafeOp,
-} from '@safe-global/safe-4337/src/utils/userOp'
-import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
-import { chainId } from '@safe-global/safe-4337/test/utils/encoding'
+} from '@safe-global/safe-4337/dist/src/utils/userOp'
+import { buildSignatureBytes } from '@safe-global/safe-4337/dist/src/utils/execution'
+import { chainId } from '@safe-global/safe-4337/dist/test/utils/encoding'
 
 /**
  * User story: Rotate passkey owner
@@ -60,8 +60,8 @@ describe('Rotate passkey owner [@userstory]', () => {
     })
 
     const publicKey = decodePublicKey(credential.response)
-    await signerFactory.createSigner(publicKey.x, publicKey.y, verifier.target)
-    const signer = await signerFactory.getSigner(publicKey.x, publicKey.y, verifier.target)
+    await signerFactory.createSigner(publicKey.x, publicKey.y, FCLP256Verifier.address)
+    const signer = await signerFactory.getSigner(publicKey.x, publicKey.y, FCLP256Verifier.address)
 
     // The initializer data to enable the Safe4337Module as a module on a Safe
     const initializer = safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]])
@@ -103,6 +103,7 @@ describe('Rotate passkey owner [@userstory]', () => {
   it('should execute a userOp with replaced WebAuthn signer as Safe owner', async () => {
     // Step 1: Setup the contracts
     const { user, module, entryPoint, verifier, navigator, SafeL2, signer, signerFactory, safeAddress } = await setupTests()
+    const verifierAddress = await verifier.getAddress()
 
     // Check the owners of the created Safe
     const safeInstance = await ethers.getContractAt(SafeL2.abi, safeAddress)
@@ -128,8 +129,8 @@ describe('Rotate passkey owner [@userstory]', () => {
     })
 
     const publicKeyNew = decodePublicKey(credentialNew.response)
-    await signerFactory.createSigner(publicKeyNew.x, publicKeyNew.y, verifier.target)
-    const signerNew = await signerFactory.getSigner(publicKeyNew.x, publicKeyNew.y, verifier.target)
+    await signerFactory.createSigner(publicKeyNew.x, publicKeyNew.y, verifierAddress)
+    const signerNew = await signerFactory.getSigner(publicKeyNew.x, publicKeyNew.y, verifierAddress)
 
     const data = safeInstance.interface.encodeFunctionData('swapOwner', [user.address, signer, signerNew])
 

--- a/modules/passkey/test/utils/hardhat.ts
+++ b/modules/passkey/test/utils/hardhat.ts
@@ -1,0 +1,5 @@
+import { ethers } from 'hardhat'
+
+export const chainId = async (): Promise<bigint> => {
+  return (await ethers.provider.getNetwork()).chainId
+}

--- a/modules/passkey/tsconfig.json
+++ b/modules/passkey/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "hardhat.config.ts", "test"]
+  "include": ["src/**/*.ts", "hardhat.config.ts", "test", "typechain-types"]
 }


### PR DESCRIPTION
I needed to import types for the example application type from the passkey package and I discovered that types were not included in the production build

This PR:
- Adds `typechain-types` folder to the build in typescript config
- Fixes the type errors that arose

Notes:
- The PR doesn't include other type improvements --> for example, there are many occurrences of `new ethers.Contract(abi, address, provider)` which would be of a high-level type `Contract`, but we have a type for the contract and could cast it to a more narrow type
- After the PR gets approved, I will create pump the package version number and push a beta release 