### PR TITLE
Passkey: release `0.2.0-alpha.0`

### DIFF
--- a/modules/passkey/package.json
+++ b/modules/passkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-passkey",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.0",
   "author": "@safe-global",
   "description": "Safe Passkey Owner",
   "homepage": "https://github.com/safe-global/safe-modules/tree/main/modules/passkey",


### PR DESCRIPTION
This PR bumps the version of the passkey package to 0.2.0-alpha.0 

Changes:
- Add `typechain-types` to the package

Following the release, we will also deprecate version 0.1.0