### PR TITLE
Passkey: Generate declaration files, bump version to alpha.1

### DIFF
--- a/modules/passkey/package.json
+++ b/modules/passkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-passkey",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0-alpha.1",
   "author": "@safe-global",
   "description": "Safe Passkey Owner",
   "homepage": "https://github.com/safe-global/safe-modules/tree/main/modules/passkey",

--- a/modules/passkey/tsconfig.json
+++ b/modules/passkey/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "declaration": true,
     "outDir": "./dist",
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This PR fixes the bug where the build didn't include typescript declaration files (*.d.ts) by setting the corresponding option to `true` in the typescript config. It also bumps the version number to `0.2.0-alpha.1`