### PR TITLE
Verify WebAuthn Signature Encoding

### DIFF
--- a/modules/4337/.solhint.json
+++ b/modules/4337/.solhint.json
@@ -13,6 +13,6 @@
     "reason-string": "off",
     "no-empty-blocks": "off",
     "avoid-low-level-calls": "off",
-    "custom-errors": "off"
+    "gas-custom-errors": "off"
   }
 }

--- a/modules/passkey/.solhint.json
+++ b/modules/passkey/.solhint.json
@@ -13,6 +13,6 @@
     "reason-string": "off",
     "no-empty-blocks": "off",
     "avoid-low-level-calls": "off",
-    "custom-errors": "off"
+    "gas-custom-errors": "off"
   }
 }

--- a/modules/passkey/contracts/libraries/WebAuthn.sol
+++ b/modules/passkey/contracts/libraries/WebAuthn.sol
@@ -100,6 +100,8 @@ library WebAuthn {
             // boundaries. This allows for high interoperability (as this is how Solidity and most
             // tools `abi.encode`s the `Signature` struct) while setting a strict upper bound to how
             // many additional padding bytes can be added to the signature, increasing gas costs.
+            // Note that we compute the aligned lengths with the formula: `l + 0x1f & ~0x1f`, which
+            // rounds `l` up to the next 32-byte boundary.
             uint256 alignmentMask = ~uint256(0x1f);
             uint256 authenticatorDataAlignedLength = (authenticatorDataLength + 0x1f) & alignmentMask;
             uint256 clientDataFieldsAlignedLength = (clientDataFieldsLength + 0x1f) & alignmentMask;

--- a/modules/passkey/contracts/libraries/WebAuthn.sol
+++ b/modules/passkey/contracts/libraries/WebAuthn.sol
@@ -68,6 +68,60 @@ library WebAuthn {
     AuthenticatorFlags internal constant USER_VERIFICATION = AuthenticatorFlags.wrap(0x04);
 
     /**
+     * @notice Casts calldata bytes to a WebAuthn signature data structure.
+     * @param signature The calldata bytes of the WebAuthn signature.
+     * @return isValid Whether or not the encoded signature bytes is valid.
+     * @return data A pointer to the signature data in calldata.
+     * @dev This method casts the dynamic bytes array to a signature calldata pointer with some
+     * additional verification. Specifically, we ensure that the signature bytes is encoded in the
+     * standard ABI encoding form, without additional padding bytes, to prevent attacks where valid
+     * signatures are padded with 0s in order to increase signature verifications the costs for
+     * ERC-4337 user operations.
+     */
+    function castSignature(bytes calldata signature) internal pure returns (bool isValid, Signature calldata data) {
+        uint256 authenticatorDataLength;
+        uint256 clientDataFieldsLength;
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            data := signature.offset
+
+            // Read the lengths of the dynamic byte arrays in assembly. This is done because
+            // Solidity generates calldata bounds checks which aren't required for the security of
+            // the signature verification, as it can only lead to _shorter_ signatures which are
+            // are less gas expensive anyway.
+            authenticatorDataLength := calldataload(add(data, calldataload(data)))
+            clientDataFieldsLength := calldataload(add(data, calldataload(add(data, 0x20))))
+        }
+
+        // Use of unchecked math as any overflows in dynamic length computations would cause
+        // out-of-gas reverts when computing the WebAuthn signing message.
+        unchecked {
+            // Allow for signature encodings where the dynamic bytes are aligned to 32-byte
+            // boundaries. This allows for high interoperability (as this is how Solidity and most
+            // tools `abi.encode`s the `Signature` struct) while setting a strict upper bound to how
+            // many additional padding bytes can be added to the signature, increasing gas costs.
+            uint256 alignmentMask = ~uint256(0x1f);
+            uint256 authenticatorDataAlignedLength = (authenticatorDataLength + 0x1f) & alignmentMask;
+            uint256 clientDataFieldsAlignedLength = (clientDataFieldsLength + 0x1f) & alignmentMask;
+
+            // The fixed parts of the signature length are 6 32-byte words for a total of 196 bytes:
+            // - offset of the `authenticatorData` bytes
+            // - offset of the `clientDataFields` string
+            // - signature `r` value
+            // - signature `s` value
+            // - length of the `authenticatorData` bytes
+            // - length of the `clientDataFields` string
+            //
+            // This implies that the signature length must be less than or equal to:
+            //      196 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength
+            // which is equivalent to strictly less than:
+            //      197 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength
+            isValid = signature.length < 197 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength;
+        }
+    }
+
+    /**
      * @notice Encodes the client data JSON string from the specified challenge, and additional
      * client data fields.
      * @dev The client data JSON follows a very specific encoding process outlined in the Web
@@ -239,7 +293,7 @@ library WebAuthn {
         P256.Verifiers verifiers
     ) internal view returns (bool success) {
         Signature calldata signatureStruct;
-        (success, signatureStruct) = _castSignature(signature);
+        (success, signatureStruct) = castSignature(signature);
         if (success) {
             success = verifySignature(challenge, signatureStruct, authenticatorFlags, x, y, verifiers);
         }
@@ -271,78 +325,6 @@ library WebAuthn {
         bytes memory message = encodeSigningMessage(challenge, signature.authenticatorData, signature.clientDataFields);
         if (checkAuthenticatorFlags(signature.authenticatorData, authenticatorFlags)) {
             success = verifiers.verifySignatureAllowMalleability(_sha256(message), signature.r, signature.s, x, y);
-        }
-    }
-
-    /**
-     * @notice Casts calldata bytes to a WebAuthn signature data structure.
-     * @param signature The calldata bytes of the WebAuthn signature.
-     * @return isValid Whether or not the encoded signature bytes is valid.
-     * @return data A pointer to the signature data in calldata.
-     * @dev This method casts the dynamic bytes array to a signature calldata pointer with some
-     * additional verification. Specifically, we ensure that the signature bytes is encoded in the
-     * standard ABI encoding form, without additional padding bytes, to prevent attacks where valid
-     * signatures are padded with 0s in order to increase signature verifications the costs for
-     * ERC-4337 user operations. Additionally, this means that invalid signatures will cause the
-     * check signature function to return `false` instead of reverting, which is the expected
-     * behaviour for signature verification in ERC-4337.
-     */
-    function _castSignature(bytes calldata signature) private pure returns (bool isValid, Signature calldata data) {
-        uint256 authenticatorDataLength;
-        uint256 clientDataFieldsLength;
-
-        // solhint-disable-next-line no-inline-assembly
-        assembly ("memory-safe") {
-            data := signature.offset
-
-            // We read the length of the `bytes calldata` fields of the assembly structure in
-            // assembly, this ensures that Solidity does not revert in cases where we want to return
-            // `false` for incorrectly encoded signatures when accessing a `bytes calldata` field
-            // that points to somewhere outside of calldata (which would generate reverting code).
-            authenticatorDataLength := calldataload(add(data, calldataload(data)))
-            clientDataFieldsLength := calldataload(add(data, calldataload(add(data, 0x20))))
-        }
-
-        // Use of unchecked math so that we can manually check for overflows and return that the
-        // signature is invalid instead of reverting.
-        unchecked {
-            // Allow for signature encodings with and without aligning the bytes to 32-byte
-            // boundaries. This allows for slightly more efficient encoding of the `Signature` data,
-            // and only introducing very small amount of additional gas variance costs.
-            uint256 alignmentMask = ~uint256(0x1f);
-            uint256 authenticatorDataAlignedLength = (authenticatorDataLength + 0x1f) & alignmentMask;
-            uint256 clientDataFieldsAlignedLength = (clientDataFieldsLength + 0x1f) & alignmentMask;
-
-            // The fixed parts of the signature length are 6 32-byte words for a total of 196 bytes:
-            // - offset of the `authenticatorData` bytes
-            // - offset of the `clientDataFields` string
-            // - signature `r` value
-            // - signature `s` value
-            // - length of the `authenticatorData` bytes
-            // - length of the `clientDataFields` string
-            //
-            // This implies that the signature length must be in the range:
-            //      [196 + authenticatorDataLength + clientDataFieldsLength,
-            //       196 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength]
-            // or, with strict inequalities:
-            //      (195 + authenticatorDataLength + clientDataFieldsLength,
-            //       197 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength)
-            uint256 minLengthMinusOne = 195 + authenticatorDataLength + clientDataFieldsLength;
-            uint256 maxLengthPlusOne = 197 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength;
-
-            // Solidity generates conditional jump statements for `&&` and `||`, as they are
-            // short-cutting logical operators. We don't want that here, so use assembly:
-            // solhint-disable-next-line no-inline-assembly
-            uint256 signatureLength = signature.length;
-            assembly ("memory-safe") {
-                isValid := and(
-                    // ensure were no overflows because of the lengths. We don't check overflows in
-                    // individual operations, but just in the final result.
-                    and(gt(minLengthMinusOne, authenticatorDataLength), gt(minLengthMinusOne, clientDataFieldsLength)),
-                    // Check that the signature bytes length is in the valid range.
-                    and(gt(signatureLength, minLengthMinusOne), lt(signatureLength, maxLengthPlusOne))
-                )
-            }
         }
     }
 

--- a/modules/passkey/contracts/libraries/WebAuthn.sol
+++ b/modules/passkey/contracts/libraries/WebAuthn.sol
@@ -105,7 +105,7 @@ library WebAuthn {
             uint256 authenticatorDataAlignedLength = (authenticatorDataLength + 0x1f) & alignmentMask;
             uint256 clientDataFieldsAlignedLength = (clientDataFieldsLength + 0x1f) & alignmentMask;
 
-            // The fixed parts of the signature length are 6 32-byte words for a total of 196 bytes:
+            // The fixed parts of the signature length are 6 32-byte words for a total of 192 bytes:
             // - offset of the `authenticatorData` bytes
             // - offset of the `clientDataFields` string
             // - signature `r` value
@@ -114,10 +114,10 @@ library WebAuthn {
             // - length of the `clientDataFields` string
             //
             // This implies that the signature length must be less than or equal to:
-            //      196 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength
+            //      192 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength
             // which is equivalent to strictly less than:
-            //      197 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength
-            isValid = signature.length < 197 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength;
+            //      193 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength
+            isValid = signature.length < 193 + authenticatorDataAlignedLength + clientDataFieldsAlignedLength;
         }
     }
 

--- a/modules/passkey/contracts/libraries/WebAuthn.sol
+++ b/modules/passkey/contracts/libraries/WebAuthn.sol
@@ -73,10 +73,9 @@ library WebAuthn {
      * @return isValid Whether or not the encoded signature bytes is valid.
      * @return data A pointer to the signature data in calldata.
      * @dev This method casts the dynamic bytes array to a signature calldata pointer with some
-     * additional verification. Specifically, we ensure that the signature bytes is encoded in the
-     * standard ABI encoding form, without additional padding bytes, to prevent attacks where valid
-     * signatures are padded with 0s in order to increase signature verifications the costs for
-     * ERC-4337 user operations.
+     * additional verification. Specifically, we ensure that the signature bytes encoding is no
+     * larger than standard ABI encoding form, to prevent attacks where valid signatures are padded
+     * with 0s in order to increase signature verifications the costs for ERC-4337 user operations.
      */
     function castSignature(bytes calldata signature) internal pure returns (bool isValid, Signature calldata data) {
         uint256 authenticatorDataLength;

--- a/modules/passkey/contracts/test/TestWebAuthnLib.sol
+++ b/modules/passkey/contracts/test/TestWebAuthnLib.sol
@@ -4,6 +4,12 @@ pragma solidity ^0.8.0;
 import {P256, WebAuthn} from "../libraries/WebAuthn.sol";
 
 contract TestWebAuthnLib {
+    function castSignature(bytes calldata signature) external pure returns (WebAuthn.Signature calldata data) {
+        bool success;
+        (success, data) = WebAuthn.castSignature(signature);
+        require(success, "WebAuthnLib: invalid signature");
+    }
+
     function encodeClientDataJson(
         bytes32 challenge,
         string calldata clientDataFields

--- a/modules/passkey/contracts/test/TestWebAuthnLib.sol
+++ b/modules/passkey/contracts/test/TestWebAuthnLib.sol
@@ -7,7 +7,7 @@ contract TestWebAuthnLib {
     function castSignature(bytes calldata signature) external pure returns (WebAuthn.Signature calldata data) {
         bool success;
         (success, data) = WebAuthn.castSignature(signature);
-        require(success, "WebAuthnLib: invalid signature");
+        require(success, "WebAuthnLib: invalid signature encoding");
     }
 
     function encodeClientDataJson(

--- a/modules/passkey/contracts/test/TestWebAuthnLib.sol
+++ b/modules/passkey/contracts/test/TestWebAuthnLib.sol
@@ -7,7 +7,7 @@ contract TestWebAuthnLib {
     function castSignature(bytes calldata signature) external pure returns (WebAuthn.Signature calldata data) {
         bool success;
         (success, data) = WebAuthn.castSignature(signature);
-        require(success, "WebAuthnLib: invalid signature encoding");
+        require(success, "invalid signature encoding");
     }
 
     function encodeClientDataJson(

--- a/modules/passkey/test/libraries/WebAuthn.spec.ts
+++ b/modules/passkey/test/libraries/WebAuthn.spec.ts
@@ -114,7 +114,9 @@ describe('WebAuthn Library', () => {
         [signature.authenticatorData, signature.clientDataFields, signature.r, signature.s],
       )
 
-      await expect(webAuthnLib.castSignature(ethers.concat([signatureBytes, '0x00']))).to.be.revertedWith('WebAuthnLib: invalid signature')
+      await expect(webAuthnLib.castSignature(ethers.concat([signatureBytes, '0x00']))).to.be.revertedWith(
+        'WebAuthnLib: invalid signature encoding',
+      )
     })
   })
 

--- a/modules/passkey/test/libraries/WebAuthn.spec.ts
+++ b/modules/passkey/test/libraries/WebAuthn.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { deployments, ethers } from 'hardhat'
-import { DUMMY_CLIENT_DATA_FIELDS, base64UrlEncode, getSignatureBytes } from '../../src/utils/webauthn'
+import { DUMMY_AUTHENTICATOR_DATA, DUMMY_CLIENT_DATA_FIELDS, base64UrlEncode, getSignatureBytes } from '../../src/utils/webauthn'
 
 const base64 = {
   encodeFromHex: (h: string) => {
@@ -17,6 +17,105 @@ describe('WebAuthn Library', () => {
     const mockP256Verifier = await (await ethers.getContractFactory('MockContract')).deploy()
 
     return { webAuthnLib, mockP256Verifier }
+  })
+
+  describe('castSignature', function () {
+    it('Should correctly cast an ABI encoded WebAuthn signature', async () => {
+      const { webAuthnLib } = await setupTests()
+
+      const signature = {
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: DUMMY_CLIENT_DATA_FIELDS,
+        r: 42n,
+        s: 1337n,
+      }
+
+      expect(
+        await webAuthnLib.castSignature(
+          ethers.AbiCoder.defaultAbiCoder().encode(
+            ['bytes', 'string', 'uint256', 'uint256'],
+            [signature.authenticatorData, signature.clientDataFields, signature.r, signature.s],
+          ),
+        ),
+      ).to.deep.equal([ethers.hexlify(signature.authenticatorData), signature.clientDataFields, signature.r, signature.s])
+    })
+
+    it('Should correctly cast a packed encoded WebAuthn signature', async () => {
+      const { webAuthnLib } = await setupTests()
+
+      const signature = {
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: DUMMY_CLIENT_DATA_FIELDS,
+        r: 42n,
+        s: 1337n,
+      }
+
+      expect(
+        await webAuthnLib.castSignature(
+          ethers.solidityPacked(
+            ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes', 'uint256', 'string'],
+            [
+              128, // offset of authenticator data
+              160 + signature.authenticatorData.length, // offset of client data fields
+              signature.r,
+              signature.s,
+              signature.authenticatorData.length,
+              signature.authenticatorData,
+              signature.clientDataFields.length,
+              signature.clientDataFields,
+            ],
+          ),
+        ),
+      ).to.deep.equal([ethers.hexlify(signature.authenticatorData), signature.clientDataFields, signature.r, signature.s])
+    })
+
+    it('Should correctly cast a partially packed encoded WebAuthn signature', async () => {
+      const { webAuthnLib } = await setupTests()
+
+      const signature = {
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: DUMMY_CLIENT_DATA_FIELDS,
+        r: 42n,
+        s: 1337n,
+      }
+
+      expect(
+        await webAuthnLib.castSignature(
+          ethers.solidityPacked(
+            ['uint256', 'uint256', 'uint256', 'uint256', 'bytes1', 'uint256', 'bytes', 'bytes2', 'uint256', 'string'],
+            [
+              128 + 1, // offset of authenticator data
+              160 + signature.authenticatorData.length + 3, // offset of client data fields
+              signature.r,
+              signature.s,
+              '0x00', // padding
+              signature.authenticatorData.length,
+              signature.authenticatorData,
+              '0x0000', // padding
+              signature.clientDataFields.length,
+              signature.clientDataFields,
+            ],
+          ),
+        ),
+      ).to.deep.equal([ethers.hexlify(signature.authenticatorData), signature.clientDataFields, signature.r, signature.s])
+    })
+
+    it('Should detect encoded WebAuthn signatures with too much padding', async () => {
+      const { webAuthnLib } = await setupTests()
+
+      const signature = {
+        authenticatorData: DUMMY_AUTHENTICATOR_DATA,
+        clientDataFields: DUMMY_CLIENT_DATA_FIELDS,
+        r: 42n,
+        s: 1337n,
+      }
+      const signatureBytes = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['bytes', 'string', 'uint256', 'uint256'],
+        [signature.authenticatorData, signature.clientDataFields, signature.r, signature.s],
+      )
+
+      await expect(webAuthnLib.castSignature(ethers.concat([signatureBytes, '0x00']))).to.be.revertedWith('WebAuthnLib: invalid signature')
+    })
   })
 
   describe('encodeClientDataJson', function () {

--- a/modules/passkey/test/libraries/WebAuthn.spec.ts
+++ b/modules/passkey/test/libraries/WebAuthn.spec.ts
@@ -114,9 +114,7 @@ describe('WebAuthn Library', () => {
         [signature.authenticatorData, signature.clientDataFields, signature.r, signature.s],
       )
 
-      await expect(webAuthnLib.castSignature(ethers.concat([signatureBytes, '0x00']))).to.be.revertedWith(
-        'WebAuthnLib: invalid signature encoding',
-      )
+      await expect(webAuthnLib.castSignature(ethers.concat([signatureBytes, '0x00']))).to.be.revertedWith('invalid signature encoding')
     })
   })
 


### PR DESCRIPTION
This PR adds logic to verify the WebAuthn signature encoding length. This is done so that encodings have a strict upper bound (determined by the 'standard' ABI encoding of the `WebAuthn.Signature` struct) on the length of the signatures.

This prevents a potential griefing attack where the signature that is sent to an ERC-4337 bundler could be arbitrarily padded with additional `0`s (which would have trivial increases to the `calldatasize` with onchain LZMA calldata decompression that already exists) while causing accounts to pay significantly more in gas costs for signature verification (bounded by the `verificationGasLimit`).