### PR TITLE
100% Branch Coverage On Contracts

### DIFF
--- a/modules/passkey/contracts/SafeWebAuthnSignerFactory.sol
+++ b/modules/passkey/contracts/SafeWebAuthnSignerFactory.sol
@@ -51,7 +51,7 @@ contract SafeWebAuthnSignerFactory is ISafeSignerFactory {
 
         if (_hasNoCode(signer)) {
             SafeWebAuthnSignerProxy created = new SafeWebAuthnSignerProxy{salt: bytes32(0)}(address(SINGLETON), x, y, verifiers);
-            require(address(created) == signer);
+            assert(address(created) == signer);
             emit Created(signer, x, y, verifiers);
         }
     }

--- a/modules/passkey/test/libraries/WebAuthn.spec.ts
+++ b/modules/passkey/test/libraries/WebAuthn.spec.ts
@@ -221,5 +221,27 @@ describe('WebAuthn Library', () => {
 
       expect(await webAuthnLib.verifySignatureCastSig(challenge, signatureBytes, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.true
     })
+
+    it('Should return false when the signature data has too much padding', async () => {
+      const { webAuthnLib, mockP256Verifier } = await setupTests()
+      const mockP256VerifierAddress = await mockP256Verifier.getAddress()
+      await mockP256Verifier.givenAnyReturnBool(true)
+
+      const authenticatorData = ethers.randomBytes(100)
+      authenticatorData[32] = 0x01
+
+      const challenge = ethers.randomBytes(32)
+      const signature = {
+        authenticatorData,
+        clientDataFields: DUMMY_CLIENT_DATA_FIELDS,
+        r: 0n,
+        s: 0n,
+      }
+      const signatureBytes = getSignatureBytes(signature)
+      const paddedSignatureBytes = ethers.concat([signatureBytes, '0x00'])
+
+      expect(await webAuthnLib.verifySignatureCastSig(challenge, signatureBytes, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.true
+      expect(await webAuthnLib.verifySignatureCastSig(challenge, paddedSignatureBytes, '0x01', 0n, 0n, mockP256VerifierAddress)).to.be.false
+    })
   })
 })


### PR DESCRIPTION
This PR gets us to 100% branch coverage on all contracts, the two that didn't have 100% coverage were:

- `SafeWebAuthnSignerFactory`: There was a `require` for something that should never be false, so it was changed to an `assert`
- `WebAuthn`: There was an else path that wasn't covered, so an additional unit test for that branch was added