### PR TITLE
Add Additional ERC-4337 Related Passkey Tests

### DIFF
--- a/modules/passkey/test/4337/SafeWebAuthnSigner.spec.ts
+++ b/modules/passkey/test/4337/SafeWebAuthnSigner.spec.ts
@@ -1,0 +1,300 @@
+import { expect } from 'chai'
+import { deployments, ethers } from 'hardhat'
+import { buildSignatureBytes, logGas } from '@safe-global/safe-4337/src/utils/execution'
+import {
+  buildSafeUserOpTransaction,
+  buildPackedUserOperationFromSafeUserOperation,
+  calculateSafeOperationHash,
+  signSafeOp,
+} from '@safe-global/safe-4337/src/utils/userOp'
+import { encodeMultiSendTransactions } from '@safe-global/safe-4337/test/utils/encoding'
+import { Safe4337 } from '@safe-global/safe-4337/src/utils/safe'
+import { WebAuthnCredentials } from '../utils/webauthnShim'
+import { decodePublicKey, encodeWebAuthnSignature } from '../../src/utils/webauthn'
+
+describe('SafeWebAuthnSigner', () => {
+  const setupTests = deployments.createFixture(async ({ deployments }) => {
+    const { SafeModuleSetup, SafeL2, SafeProxyFactory, MultiSend, FCLP256Verifier, Safe4337Module, EntryPoint, SafeWebAuthnSignerFactory } =
+      await deployments.fixture()
+
+    const { chainId } = await ethers.provider.getNetwork()
+    const [user] = await ethers.getSigners()
+
+    const entryPoint = await ethers.getContractAt('IEntryPoint', EntryPoint.address)
+    const module = await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)
+    const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
+    const multiSend = await ethers.getContractAt('MultiSend', MultiSend.address)
+    const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
+    const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
+
+    const verifiers = BigInt(FCLP256Verifier.address)
+
+    const navigator = {
+      credentials: new WebAuthnCredentials(),
+    }
+
+    return {
+      chainId,
+      user,
+      proxyFactory,
+      multiSend,
+      safeModuleSetup,
+      module,
+      entryPoint,
+      singleton,
+      signerFactory,
+      verifiers,
+      navigator,
+    }
+  })
+
+  describe('executeUserOp - new account', () => {
+    it('should execute user operation with a pre-deployed signer', async () => {
+      const { chainId, user, proxyFactory, safeModuleSetup, module, entryPoint, singleton, signerFactory, navigator, verifiers } =
+        await setupTests()
+      const credential = navigator.credentials.create({
+        publicKey: {
+          rp: {
+            name: 'Safe',
+            id: 'safe.global',
+          },
+          user: {
+            id: ethers.getBytes(ethers.id('chucknorris')),
+            name: 'chucknorris',
+            displayName: 'Chuck Norris',
+          },
+          challenge: ethers.toBeArray(Date.now()),
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+        },
+      })
+      const publicKey = decodePublicKey(credential.response)
+      await signerFactory.createSigner(publicKey.x, publicKey.y, verifiers)
+      const signer = await ethers.getContractAt(
+        'SafeWebAuthnSignerProxy',
+        await signerFactory.getSigner(publicKey.x, publicKey.y, verifiers),
+      )
+
+      const safe = await Safe4337.withSigner(await signer.getAddress(), {
+        safeSingleton: await singleton.getAddress(),
+        entryPoint: await entryPoint.getAddress(),
+        erc4337module: await module.getAddress(),
+        proxyFactory: await proxyFactory.getAddress(),
+        safeModuleSetup: await safeModuleSetup.getAddress(),
+        proxyCreationCode: await proxyFactory.proxyCreationCode(),
+        chainId: Number(chainId),
+      })
+
+      const safeOp = buildSafeUserOpTransaction(
+        safe.address,
+        user.address,
+        ethers.parseEther('0.5'),
+        '0x',
+        '0',
+        await entryPoint.getAddress(),
+        false,
+        false,
+        {
+          initCode: safe.getInitCode(),
+          verificationGasLimit: 625000,
+        },
+      )
+      const safeOpHash = calculateSafeOperationHash(await module.getAddress(), safeOp, chainId)
+      const assertion = navigator.credentials.get({
+        publicKey: {
+          challenge: ethers.getBytes(safeOpHash),
+          rpId: 'safe.global',
+          allowCredentials: [{ type: 'public-key', id: new Uint8Array(credential.rawId) }],
+          userVerification: 'required',
+        },
+      })
+      const signature = buildSignatureBytes([
+        {
+          signer: signer.target as string,
+          data: encodeWebAuthnSignature(assertion.response),
+          dynamic: true,
+        },
+      ])
+
+      await user.sendTransaction({ to: safe.address, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+      expect(await ethers.provider.getCode(safe.address)).to.equal('0x')
+      expect(await ethers.provider.getBalance(safe.address)).to.equal(ethers.parseEther('1'))
+
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
+      await logGas('WebAuthn signer Safe operation', entryPoint.handleOps([userOp], user.address))
+
+      expect(await ethers.provider.getCode(safe.address)).to.not.equal('0x')
+      expect(await ethers.provider.getBalance(safe.address)).to.be.lessThanOrEqual(ethers.parseEther('0.5'))
+    })
+
+    it('should execute user operation from a 1/2 Safe with a passkey owner', async () => {
+      const {
+        chainId,
+        user,
+        proxyFactory,
+        safeModuleSetup,
+        module,
+        entryPoint,
+        singleton,
+        multiSend,
+        signerFactory,
+        navigator,
+        verifiers,
+      } = await setupTests()
+      const credential = navigator.credentials.create({
+        publicKey: {
+          rp: {
+            name: 'Safe',
+            id: 'safe.global',
+          },
+          user: {
+            id: ethers.getBytes(ethers.id('chucknorris')),
+            name: 'chucknorris',
+            displayName: 'Chuck Norris',
+          },
+          challenge: ethers.toBeArray(Date.now()),
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+        },
+      })
+      const publicKey = decodePublicKey(credential.response)
+      const signer = await ethers.getContractAt(
+        'SafeWebAuthnSignerProxy',
+        await signerFactory.getSigner(publicKey.x, publicKey.y, verifiers),
+      )
+
+      const safe = await Safe4337.withConfigs(
+        {
+          signers: [user.address, await signer.getAddress()],
+          threshold: 1,
+          nonce: 0,
+        },
+        {
+          safeSingleton: await singleton.getAddress(),
+          entryPoint: await entryPoint.getAddress(),
+          erc4337module: await module.getAddress(),
+          proxyFactory: await proxyFactory.getAddress(),
+          safeModuleSetup: await safeModuleSetup.getAddress(),
+          proxyCreationCode: await proxyFactory.proxyCreationCode(),
+          chainId: Number(chainId),
+        },
+      )
+
+      const safeOp = buildSafeUserOpTransaction(
+        safe.address,
+        await multiSend.getAddress(),
+        ethers.parseEther('0.5'),
+        multiSend.interface.encodeFunctionData('multiSend', [
+          encodeMultiSendTransactions([
+            {
+              op: 0,
+              to: user.address,
+              value: ethers.parseEther('0.5'),
+              data: '0x',
+            },
+            {
+              op: 0,
+              to: await signerFactory.getAddress(),
+              value: 0,
+              data: signerFactory.interface.encodeFunctionData('createSigner', [publicKey.x, publicKey.y, verifiers]),
+            },
+          ]),
+        ]),
+        '0',
+        await entryPoint.getAddress(),
+        true, // DELEGATECALL
+        false,
+        {
+          initCode: safe.getInitCode(),
+        },
+      )
+      const signature = buildSignatureBytes([await signSafeOp(user, await module.getAddress(), safeOp, chainId)])
+
+      await user.sendTransaction({ to: safe.address, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+      expect(await ethers.provider.getCode(safe.address)).to.equal('0x')
+      expect(await ethers.provider.getCode(await signer.getAddress())).to.equal('0x')
+      expect(await ethers.provider.getBalance(safe.address)).to.equal(ethers.parseEther('1'))
+
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
+      await logGas('WebAuthn signer Safe operation', entryPoint.handleOps([userOp], user.address))
+
+      expect(await ethers.provider.getCode(safe.address)).to.not.equal('0x')
+      expect(await ethers.provider.getCode(await signer.getAddress())).to.not.equal('0x')
+      expect(await ethers.provider.getBalance(safe.address)).to.be.lessThanOrEqual(ethers.parseEther('0.5'))
+
+      const safeInstance = new ethers.Contract(safe.address, singleton.interface, ethers.provider)
+      expect(await safeInstance.isOwner(await signer.getAddress())).to.be.true
+    })
+  })
+
+  describe('executeUserOp - existing account', () => {
+    it('should execute user operation', async () => {
+      const { chainId, user, proxyFactory, safeModuleSetup, module, entryPoint, singleton, signerFactory, navigator, verifiers } =
+        await setupTests()
+      const credential = navigator.credentials.create({
+        publicKey: {
+          rp: {
+            name: 'Safe',
+            id: 'safe.global',
+          },
+          user: {
+            id: ethers.getBytes(ethers.id('chucknorris')),
+            name: 'chucknorris',
+            displayName: 'Chuck Norris',
+          },
+          challenge: ethers.toBeArray(Date.now()),
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+        },
+      })
+      const publicKey = decodePublicKey(credential.response)
+      await signerFactory.createSigner(publicKey.x, publicKey.y, verifiers)
+      const signer = await ethers.getContractAt(
+        'SafeWebAuthnSignerProxy',
+        await signerFactory.getSigner(publicKey.x, publicKey.y, verifiers),
+      )
+
+      const safe = await Safe4337.withSigner(await signer.getAddress(), {
+        safeSingleton: await singleton.getAddress(),
+        entryPoint: await entryPoint.getAddress(),
+        erc4337module: await module.getAddress(),
+        proxyFactory: await proxyFactory.getAddress(),
+        safeModuleSetup: await safeModuleSetup.getAddress(),
+        proxyCreationCode: await proxyFactory.proxyCreationCode(),
+        chainId: Number(chainId),
+      })
+      await safe.deploy(user)
+
+      const safeOp = buildSafeUserOpTransaction(
+        safe.address,
+        user.address,
+        ethers.parseEther('0.5'),
+        '0x',
+        '0',
+        await entryPoint.getAddress(),
+      )
+      const safeOpHash = calculateSafeOperationHash(await module.getAddress(), safeOp, chainId)
+      const assertion = navigator.credentials.get({
+        publicKey: {
+          challenge: ethers.getBytes(safeOpHash),
+          rpId: 'safe.global',
+          allowCredentials: [{ type: 'public-key', id: new Uint8Array(credential.rawId) }],
+          userVerification: 'required',
+        },
+      })
+      const signature = buildSignatureBytes([
+        {
+          signer: signer.target as string,
+          data: encodeWebAuthnSignature(assertion.response),
+          dynamic: true,
+        },
+      ])
+
+      await user.sendTransaction({ to: safe.address, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+      expect(await ethers.provider.getBalance(safe.address)).to.equal(ethers.parseEther('1'))
+
+      const userOp = buildPackedUserOperationFromSafeUserOperation({ safeOp, signature })
+      await logGas('WebAuthn signer Safe operation', entryPoint.handleOps([userOp], user.address))
+
+      expect(await ethers.provider.getBalance(safe.address)).to.be.lessThanOrEqual(ethers.parseEther('0.5'))
+    })
+  })
+})

--- a/modules/passkey/test/4337/local-bundler/SafeWebAuthnSigner.spec.ts
+++ b/modules/passkey/test/4337/local-bundler/SafeWebAuthnSigner.spec.ts
@@ -1,0 +1,135 @@
+import { expect } from 'chai'
+import { deployments, ethers, network } from 'hardhat'
+import { Safe4337 } from '@safe-global/safe-4337/src/utils/safe'
+import {
+  buildRpcUserOperationFromSafeUserOperation,
+  buildSafeUserOpTransaction,
+  calculateSafeOperationHash,
+} from '@safe-global/safe-4337/src/utils/userOp'
+import { bundlerRpc, prepareAccounts, waitForUserOp } from '@safe-global/safe-4337-local-bundler'
+import { WebAuthnCredentials } from '../../utils/webauthnShim'
+import { decodePublicKey, encodeWebAuthnSignature } from '../../../src/utils/webauthn'
+import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
+
+describe('Safe WebAuthn Signer [@4337]', () => {
+  before(function () {
+    if (network.name !== 'localhost') {
+      this.skip()
+    }
+  })
+
+  const setupTests = deployments.createFixture(async ({ deployments }) => {
+    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, SafeL2, FCLP256Verifier, SafeWebAuthnSignerFactory } =
+      await deployments.run()
+    const [user] = await prepareAccounts()
+    const bundler = bundlerRpc()
+
+    const entryPoint = await ethers.getContractAt('IEntryPoint', EntryPoint.address)
+    const module = await ethers.getContractAt(Safe4337Module.abi, Safe4337Module.address)
+    const proxyFactory = await ethers.getContractAt(SafeProxyFactory.abi, SafeProxyFactory.address)
+    const safeModuleSetup = await ethers.getContractAt(SafeModuleSetup.abi, SafeModuleSetup.address)
+    const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
+    const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
+
+    const navigator = {
+      credentials: new WebAuthnCredentials(),
+    }
+
+    return {
+      user,
+      bundler,
+      proxyFactory,
+      safeModuleSetup,
+      module,
+      entryPoint,
+      singleton,
+      signerFactory,
+      navigator,
+      verifier,
+    }
+  })
+
+  it('should execute a user op and deploy a WebAuthn signer', async () => {
+    const { user, bundler, proxyFactory, safeModuleSetup, module, entryPoint, singleton, signerFactory, navigator, verifier } =
+      await setupTests()
+
+    const { chainId } = await ethers.provider.getNetwork()
+    const verifiers = ethers.solidityPacked(['uint16', 'address'], [0, await verifier.getAddress()])
+
+    const credential = navigator.credentials.create({
+      publicKey: {
+        rp: {
+          name: 'Safe',
+          id: 'safe.global',
+        },
+        user: {
+          id: ethers.getBytes(ethers.id('chucknorris')),
+          name: 'chucknorris',
+          displayName: 'Chuck Norris',
+        },
+        challenge: ethers.toBeArray(Date.now()),
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      },
+    })
+    const publicKey = decodePublicKey(credential.response)
+    const signerAddress = await signerFactory.getSigner(publicKey.x, publicKey.y, verifiers)
+    await signerFactory.createSigner(publicKey.x, publicKey.y, verifiers).then((tx) => tx.wait())
+
+    const safe = await Safe4337.withSigner(signerAddress, {
+      safeSingleton: await singleton.getAddress(),
+      entryPoint: await entryPoint.getAddress(),
+      erc4337module: await module.getAddress(),
+      proxyFactory: await proxyFactory.getAddress(),
+      safeModuleSetup: await safeModuleSetup.getAddress(),
+      proxyCreationCode: await proxyFactory.proxyCreationCode(),
+      chainId: Number(chainId),
+    })
+
+    const safeOp = buildSafeUserOpTransaction(
+      safe.address,
+      user.address,
+      ethers.parseEther('0.5'),
+      '0x',
+      '0',
+      await entryPoint.getAddress(),
+      false,
+      false,
+      {
+        initCode: safe.getInitCode(),
+        verificationGasLimit: 625000,
+      },
+    )
+    const safeOpHash = calculateSafeOperationHash(await module.getAddress(), safeOp, chainId)
+    const assertion = navigator.credentials.get({
+      publicKey: {
+        challenge: ethers.getBytes(safeOpHash),
+        rpId: 'safe.global',
+        allowCredentials: [{ type: 'public-key', id: new Uint8Array(credential.rawId) }],
+        userVerification: 'required',
+      },
+    })
+    const signature = buildSignatureBytes([
+      {
+        signer: signerAddress,
+        data: encodeWebAuthnSignature(assertion.response),
+        dynamic: true,
+      },
+    ])
+
+    await user.sendTransaction({ to: safe.address, value: ethers.parseEther('1') }).then((tx) => tx.wait())
+    expect(await ethers.provider.getCode(safe.address)).to.equal('0x')
+    expect(await ethers.provider.getBalance(safe.address)).to.equal(ethers.parseEther('1'))
+
+    const userOp = await buildRpcUserOperationFromSafeUserOperation({ safeOp, signature })
+    await bundler.sendUserOperation(userOp, await entryPoint.getAddress())
+    await waitForUserOp(userOp)
+
+    expect(await ethers.provider.getBalance(safe.address)).to.be.lessThanOrEqual(ethers.parseEther('0.5'))
+    expect(await ethers.provider.getCode(safe.address)).to.not.equal('0x')
+    expect(await ethers.provider.getCode(signerAddress)).to.not.equal('0x')
+
+    const safeInstance = new ethers.Contract(safe.address, singleton.interface, ethers.provider)
+    expect(await safeInstance.getOwners()).to.deep.equal([signerAddress])
+  })
+})

--- a/modules/passkey/test/4337/local-bundler/experimental/SafeSignerLaunchpad.spec.ts
+++ b/modules/passkey/test/4337/local-bundler/experimental/SafeSignerLaunchpad.spec.ts
@@ -5,7 +5,7 @@ import { bundlerRpc, prepareAccounts, waitForUserOp } from '@safe-global/safe-43
 import { WebAuthnCredentials } from '../../../utils/webauthnShim'
 import { decodePublicKey, encodeWebAuthnSignature } from '../../../../src/utils/webauthn'
 
-describe('WebAuthn Signer Launchpad [@4337]', () => {
+describe('Safe WebAuthn Signer Launchpad [@4337]', () => {
   before(function () {
     if (network.name !== 'localhost') {
       this.skip()

--- a/modules/passkey/test/4337/local-bundler/experimental/SafeWebAuthnSharedSigner.spec.ts
+++ b/modules/passkey/test/4337/local-bundler/experimental/SafeWebAuthnSharedSigner.spec.ts
@@ -11,7 +11,7 @@ import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
 import { WebAuthnCredentials } from '../../../utils/webauthnShim'
 import { decodePublicKey, encodeWebAuthnSignature } from '../../../../src/utils/webauthn'
 
-describe('WebAuthn Singleton Signers [@4337]', () => {
+describe('Safe WebAuthn Shared Signer [@4337]', () => {
   before(function () {
     if (network.name !== 'localhost') {
       this.skip()


### PR DESCRIPTION
Follow up to #415

Now that we officially tagged the launchpad as "experimental", the module was missing unit and E2E tests demonstrating the "officially" supported way to use passkeys over ERC-4337. This PR adds both a unit test that a user operation with a passkey owner can be executed over the ERC-4337 reference entrypoint, as well as a local bundler test to ensure that no bundler rules are violated by the passkey signers.