### PR TITLE
Local Bundler Test with New Shared Signer Flow

### DIFF
--- a/modules/passkey/src/deploy/launchpad.ts
+++ b/modules/passkey/src/deploy/launchpad.ts
@@ -14,12 +14,6 @@ const deploy: DeployFunction = async ({ deployments, getNamedAccounts }) => {
     log: true,
     deterministicDeployment: true,
   })
-  await deploy('SafeWebAuthnSharedSigner', {
-    from: deployer,
-    args: [],
-    log: true,
-    deterministicDeployment: true,
-  })
 }
 
 deploy.dependencies = ['entrypoint']

--- a/modules/passkey/src/deploy/webauthn.ts
+++ b/modules/passkey/src/deploy/webauthn.ts
@@ -10,6 +10,12 @@ const deploy: DeployFunction = async ({ deployments, getNamedAccounts }) => {
     log: true,
     deterministicDeployment: true,
   })
+  await deploy('SafeWebAuthnSharedSigner', {
+    from: deployer,
+    args: [],
+    log: true,
+    deterministicDeployment: true,
+  })
 }
 
 export default deploy

--- a/modules/passkey/test/4337/local-bundler/SafeWebAuthnSigner.spec.ts
+++ b/modules/passkey/test/4337/local-bundler/SafeWebAuthnSigner.spec.ts
@@ -50,7 +50,7 @@ describe('Safe WebAuthn Signer [@4337]', () => {
     }
   })
 
-  it('should execute a user op and deploy a WebAuthn signer', async () => {
+  it('should execute a user op with a deployed WebAuthn signer', async () => {
     const { user, bundler, proxyFactory, safeModuleSetup, module, entryPoint, singleton, signerFactory, navigator, verifier } =
       await setupTests()
 

--- a/modules/passkey/test/4337/local-bundler/experimental/SafeWebAuthnSharedSigner.spec.ts
+++ b/modules/passkey/test/4337/local-bundler/experimental/SafeWebAuthnSharedSigner.spec.ts
@@ -11,6 +11,8 @@ import { buildSignatureBytes } from '@safe-global/safe-4337/src/utils/execution'
 import { WebAuthnCredentials } from '../../../utils/webauthnShim'
 import { decodePublicKey, encodeWebAuthnSignature } from '../../../../src/utils/webauthn'
 
+const SENTINEL = ethers.getAddress('0x0000000000000000000000000000000000000001')
+
 describe('Safe WebAuthn Shared Signer [@4337]', () => {
   before(function () {
     if (network.name !== 'localhost') {
@@ -19,8 +21,17 @@ describe('Safe WebAuthn Shared Signer [@4337]', () => {
   })
 
   const setupTests = deployments.createFixture(async ({ deployments }) => {
-    const { EntryPoint, Safe4337Module, SafeProxyFactory, SafeModuleSetup, MultiSend, SafeL2, FCLP256Verifier, SafeWebAuthnSharedSigner } =
-      await deployments.run()
+    const {
+      EntryPoint,
+      Safe4337Module,
+      SafeProxyFactory,
+      SafeModuleSetup,
+      MultiSend,
+      SafeL2,
+      FCLP256Verifier,
+      SafeWebAuthnSharedSigner,
+      SafeWebAuthnSignerFactory,
+    } = await deployments.run()
     const [user] = await prepareAccounts()
     const bundler = bundlerRpc()
 
@@ -31,7 +42,8 @@ describe('Safe WebAuthn Shared Signer [@4337]', () => {
     const multiSend = await ethers.getContractAt(MultiSend.abi, MultiSend.address)
     const singleton = await ethers.getContractAt(SafeL2.abi, SafeL2.address)
     const verifier = await ethers.getContractAt('IP256Verifier', FCLP256Verifier.address)
-    const signer = await ethers.getContractAt('SafeWebAuthnSharedSigner', SafeWebAuthnSharedSigner.address)
+    const sharedSigner = await ethers.getContractAt('SafeWebAuthnSharedSigner', SafeWebAuthnSharedSigner.address)
+    const signerFactory = await ethers.getContractAt('SafeWebAuthnSignerFactory', SafeWebAuthnSignerFactory.address)
 
     const navigator = {
       credentials: new WebAuthnCredentials(),
@@ -47,13 +59,14 @@ describe('Safe WebAuthn Shared Signer [@4337]', () => {
       multiSend,
       singleton,
       verifier,
-      signer,
+      sharedSigner,
+      signerFactory,
       navigator,
     }
   })
 
-  it('should execute a user op and deploy a WebAuthn signer', async () => {
-    const { user, bundler, proxyFactory, safeModuleSetup, module, entryPoint, multiSend, singleton, verifier, signer, navigator } =
+  it('should execute a user op with the WebAuthn shared signer', async () => {
+    const { user, bundler, proxyFactory, safeModuleSetup, module, entryPoint, multiSend, singleton, verifier, sharedSigner, navigator } =
       await setupTests()
     const verifierAddress = await verifier.getAddress()
 
@@ -75,7 +88,7 @@ describe('Safe WebAuthn Shared Signer [@4337]', () => {
     const publicKey = decodePublicKey(credential.response)
 
     const initializer = singleton.interface.encodeFunctionData('setup', [
-      [signer.target],
+      [sharedSigner.target],
       1,
       multiSend.target,
       multiSend.interface.encodeFunctionData('multiSend', [
@@ -87,8 +100,8 @@ describe('Safe WebAuthn Shared Signer [@4337]', () => {
           },
           {
             op: 1 as const,
-            to: signer.target,
-            data: signer.interface.encodeFunctionData('configure', [{ ...publicKey, verifiers: verifierAddress }]),
+            to: sharedSigner.target,
+            data: sharedSigner.interface.encodeFunctionData('configure', [{ ...publicKey, verifiers: verifierAddress }]),
           },
         ]),
       ]),
@@ -132,7 +145,7 @@ describe('Safe WebAuthn Shared Signer [@4337]', () => {
     })
     const signature = buildSignatureBytes([
       {
-        signer: signer.target as string,
+        signer: sharedSigner.target as string,
         data: encodeWebAuthnSignature(assertion.response),
         dynamic: true,
       },
@@ -145,13 +158,157 @@ describe('Safe WebAuthn Shared Signer [@4337]', () => {
     await user.sendTransaction({ to: safeAddress, value: ethers.parseEther('0.5') }).then((tx) => tx.wait())
 
     expect(ethers.dataLength(await ethers.provider.getCode(safeAddress))).to.equal(0)
-    expect(await signer.getConfiguration(safeAddress)).to.deep.equal([0n, 0n, 0n])
+    expect(await sharedSigner.getConfiguration(safeAddress)).to.deep.equal([0n, 0n, 0n])
 
     await bundler.sendUserOperation(userOp, await entryPoint.getAddress())
     await waitForUserOp(userOp)
 
     expect(ethers.dataLength(await ethers.provider.getCode(safeAddress))).to.not.equal(0)
     expect(await ethers.provider.getBalance(safeAddress)).to.be.lessThan(ethers.parseEther('0.4'))
-    expect(await signer.getConfiguration(safeAddress)).to.deep.equal([publicKey.x, publicKey.y, verifier.target])
+    expect(await sharedSigner.getConfiguration(safeAddress)).to.deep.equal([publicKey.x, publicKey.y, verifier.target])
+  })
+
+  it('should execute a user op and deploy a new WebAuthn signer', async () => {
+    const {
+      user,
+      bundler,
+      proxyFactory,
+      safeModuleSetup,
+      module,
+      entryPoint,
+      multiSend,
+      singleton,
+      verifier,
+      sharedSigner,
+      signerFactory,
+      navigator,
+    } = await setupTests()
+    const verifierAddress = await verifier.getAddress()
+
+    const credential = navigator.credentials.create({
+      publicKey: {
+        rp: {
+          name: 'Safe',
+          id: 'safe.global',
+        },
+        user: {
+          id: ethers.getBytes(ethers.id('chucknorris')),
+          name: 'chucknorris',
+          displayName: 'Chuck Norris',
+        },
+        challenge: ethers.toBeArray(Date.now()),
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      },
+    })
+    const publicKey = decodePublicKey(credential.response)
+    const signerAddress = await signerFactory.getSigner(publicKey.x, publicKey.y, verifierAddress)
+
+    const initializer = singleton.interface.encodeFunctionData('setup', [
+      [sharedSigner.target],
+      1,
+      multiSend.target,
+      multiSend.interface.encodeFunctionData('multiSend', [
+        encodeMultiSendTransactions([
+          {
+            op: 1 as const,
+            to: safeModuleSetup.target,
+            data: safeModuleSetup.interface.encodeFunctionData('enableModules', [[module.target]]),
+          },
+          {
+            op: 1 as const,
+            to: sharedSigner.target,
+            data: sharedSigner.interface.encodeFunctionData('configure', [{ ...publicKey, verifiers: verifierAddress }]),
+          },
+        ]),
+      ]),
+      module.target,
+      ethers.ZeroAddress,
+      0,
+      ethers.ZeroAddress,
+    ])
+    const safeSalt = Date.now()
+    const safeAddress = await proxyFactory.createProxyWithNonce.staticCall(singleton.target, initializer, safeSalt)
+    const deployData = proxyFactory.interface.encodeFunctionData('createProxyWithNonce', [singleton.target, initializer, safeSalt])
+    const initCode = ethers.solidityPacked(['address', 'bytes'], [proxyFactory.target, deployData])
+
+    const safeOp = buildSafeUserOpTransaction(
+      safeAddress,
+      await multiSend.getAddress(),
+      0,
+      multiSend.interface.encodeFunctionData('multiSend', [
+        encodeMultiSendTransactions([
+          {
+            op: 0 as const,
+            to: signerFactory.target,
+            data: signerFactory.interface.encodeFunctionData('createSigner', [publicKey.x, publicKey.y, verifierAddress]),
+          },
+          {
+            op: 0 as const,
+            to: safeAddress,
+            data: singleton.interface.encodeFunctionData('swapOwner', [SENTINEL, sharedSigner.target, signerAddress]),
+          },
+          {
+            op: 1 as const,
+            to: sharedSigner.target,
+            data: sharedSigner.interface.encodeFunctionData('configure', [{ x: 0, y: 0, verifiers: 0 }]),
+          },
+          {
+            op: 0 as const,
+            to: user.address,
+            value: ethers.parseEther('0.1'),
+            data: '0x',
+          },
+        ]),
+      ]),
+      await entryPoint.getNonce(safeAddress, 0),
+      await entryPoint.getAddress(),
+      true,
+      false,
+      {
+        initCode,
+        verificationGasLimit: 700000,
+      },
+    )
+    const opHash = await module.getOperationHash(
+      buildPackedUserOperationFromSafeUserOperation({
+        safeOp,
+        signature: '0x',
+      }),
+    )
+    const assertion = navigator.credentials.get({
+      publicKey: {
+        challenge: ethers.getBytes(opHash),
+        rpId: 'safe.global',
+        allowCredentials: [{ type: 'public-key', id: new Uint8Array(credential.rawId) }],
+        userVerification: 'required',
+      },
+    })
+    const signature = buildSignatureBytes([
+      {
+        signer: sharedSigner.target as string,
+        data: encodeWebAuthnSignature(assertion.response),
+        dynamic: true,
+      },
+    ])
+    const userOp = await buildRpcUserOperationFromSafeUserOperation({
+      safeOp,
+      signature,
+    })
+
+    await user.sendTransaction({ to: safeAddress, value: ethers.parseEther('0.5') }).then((tx) => tx.wait())
+
+    expect(ethers.dataLength(await ethers.provider.getCode(safeAddress))).to.equal(0)
+    expect(await sharedSigner.getConfiguration(safeAddress)).to.deep.equal([0n, 0n, 0n])
+
+    await bundler.sendUserOperation(userOp, await entryPoint.getAddress())
+    await waitForUserOp(userOp)
+
+    expect(ethers.dataLength(await ethers.provider.getCode(safeAddress))).to.not.equal(0)
+    expect(ethers.dataLength(await ethers.provider.getCode(signerAddress))).to.not.equal(0)
+    expect(await ethers.provider.getBalance(safeAddress)).to.be.lessThan(ethers.parseEther('0.4'))
+    expect(await sharedSigner.getConfiguration(safeAddress)).to.deep.equal([0n, 0n, 0n])
+
+    const safeInstance = singleton.attach(safeAddress) as typeof singleton
+    expect(await safeInstance.getOwners()).to.deep.equal([signerAddress])
   })
 })


### PR DESCRIPTION
This PR demonstrates that the launchpad is, in fact, kind of useless.

Specifically, a new local bundler end-to-end test is added where the shared signer is used to create a Safe that ends up with the same configuration as with the signer launchpad. It uses the shared signer as the initial owner which is used for signing **only** the first user operation. During execution of the first user operation, the Safe's owner is swapped for a freshly deployed `SafeWebAuthnSignerProxy` instead of the shared signer. This means that we end up with a Safe with a "regular" passkey owner without any of the downsides (complicated launchpad code, rigid ownership structure, only one passkey owner allowed, etc.).

If this PR is approved, I will **remove** the `SafeSignerLaunchpad` in follow up PRs as well as update the passkey example to use the same strategy so it ends up with a standard passkey owner.