### PR TITLE
Copy Docker Files To Dist Directory

### DIFF
--- a/packages/4337-local-bundler/package.json
+++ b/packages/4337-local-bundler/package.json
@@ -9,7 +9,7 @@
     "4337-local-bundler-test": "dist/src/bin/test.js"
   },
   "scripts": {
-    "build": "rimraf dist && tsc && chmod +x dist/src/bin/*.js",
+    "build": "rimraf dist && tsc && cp -r docker docker-compose.yaml dist && chmod +x dist/src/bin/*.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepare": "pnpm run build"


### PR DESCRIPTION
This PR changes the `build` command for the `4337-local-bundler` package to also copy the docker files to the `dist` output.

This became an issue for me since #420. I use `podman(-compose)` which does not have the behaviour of walking up the directory tree in order to find a `docker-compose.yaml` to use for `podman compose ...` commands. The issue lies with the fact that that this relative path:

https://github.com/safe-global/safe-modules/blob/894ac3f9564de4cadfa3270191f4fd7d9efba0ff/packages/4337-local-bundler/src/bin/test.ts#L8

Is no longer valid for build outputs since `dist` has an extra level of nesting since #420 as it includes the `hardhat.config.ts` in its build output. To fix this, the Docker compose related files are also copied to the `dist` directory, which gives us this tree and ensures that the `root` path is correct once again.

```
packages/4337-local-bundler/dist
├── docker
│   └── bundler
│       └── Dockerfile
├── docker-compose.yaml
├── hardhat.config.d.ts
├── hardhat.config.js
└── src
    ├── bin
    │   ├── test.d.ts
    │   └── test.js
    ├── deploy
    │   ├── entrypoint.d.ts
    │   ├── entrypoint.js
    │   ├── safe.d.ts
    │   └── safe.js
    ├── index.d.ts
    ├── index.js
    ├── testing.d.ts
    ├── testing.js
    └── types
        ├── hardhat.d.ts
        └── hardhat.js
```

