### PR TITLE
Fix Documentation in WebAuthn Shared Signer

### DIFF
--- a/modules/passkey/contracts/4337/experimental/SafeWebAuthnSharedSigner.sol
+++ b/modules/passkey/contracts/4337/experimental/SafeWebAuthnSharedSigner.sol
@@ -13,7 +13,8 @@ import {P256, WebAuthn} from "../../libraries/WebAuthn.sol";
 contract SafeWebAuthnSharedSigner is SignatureValidator {
     /**
      * @notice Data associated with a WebAuthn signer. It represents the X and Y coordinates of the
-     * signer's public key. This is stored in a mapping using the account address as the key.
+     * signer's public key as well as the P256 verifiers to use. This is stored in account storage
+     * starting at the storage slot {_SIGNER_SLOT}.
      */
     struct Signer {
         uint256 x;

--- a/modules/passkey/test/4337/experimental/SafeWebAuthnSharedSigner.spec.ts
+++ b/modules/passkey/test/4337/experimental/SafeWebAuthnSharedSigner.spec.ts
@@ -123,6 +123,7 @@ describe('SafeWebAuthnSharedSigner', () => {
       expect(await ethers.provider.getStorage(account, SIGNER_STORAGE_SLOT)).to.equal(config.x)
       expect(await ethers.provider.getStorage(account, BigInt(SIGNER_STORAGE_SLOT) + 1n)).to.equal(config.y)
       expect(await ethers.provider.getStorage(account, BigInt(SIGNER_STORAGE_SLOT) + 2n)).to.equal(config.verifiers)
+      expect(await ethers.provider.getStorage(account, ethers.id('SafeWebAuthnSharedSigner.signer'))).to.equal(ethers.ZeroHash)
     })
 
     it('Should revert if not DELEGATECALL-ed', async () => {


### PR DESCRIPTION
I noticed a small documentation issue in the Safe shared WebAuthn signer implementation. This PR fixes it.

In addition, I added an assertion to ensure that we don't write any storage to a slot for which we know a pre-image.
