### PR TITLE
Shared Signer Mapping

### DIFF
--- a/modules/passkey/contracts/test/TestDependencies.sol
+++ b/modules/passkey/contracts/test/TestDependencies.sol
@@ -5,5 +5,5 @@ pragma solidity >=0.8.0;
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import "@account-abstraction/contracts/samples/VerifyingPaymaster.sol";
 import "@safe-global/mock-contract/contracts/MockContract.sol";
-import "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol";
 import "@safe-global/safe-contracts/contracts/libraries/MultiSend.sol";
+import "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol";

--- a/modules/passkey/contracts/test/TestSharedWebAuthnSignerAccessor.sol
+++ b/modules/passkey/contracts/test/TestSharedWebAuthnSignerAccessor.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {SafeWebAuthnSharedSigner} from "../4337/experimental/SafeWebAuthnSharedSigner.sol";
+
+contract TestSharedWebAuthnSignerAccessor {
+    function getSignerConfiguration(address sharedSigner) external view returns (SafeWebAuthnSharedSigner.Signer memory signer) {
+        signer = _getSigners()[sharedSigner];
+    }
+
+    function _getSigners() private pure returns (mapping(address => SafeWebAuthnSharedSigner.Signer) storage signers) {
+        uint256 signersSlot = uint256(keccak256("SafeWebAuthnSharedSigner.signer")) - 1;
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            signers.slot := signersSlot
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the behaviour of the shared signer to store its configuration as if it were behind a mapping where the key is the shared signer address. This allows multiple shared signer instances to be configured for a single account (in case you ever need to deploy a 2/2 Safe owned by passkeys with 4337).

I created an "accessor" contract to prove that the storage location is indeed the equivalent to a `mapping(address self => Signer)`.