### PR TITLE
Remove Docker Compose Version

### DIFF
--- a/modules/passkey/docker-compose.yaml
+++ b/modules/passkey/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+name: safe-passkey
 
 services:
   geth:

--- a/packages/4337-local-bundler/docker-compose.yaml
+++ b/packages/4337-local-bundler/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+name: safe-4337-local-bundler
 
 services:
   geth:


### PR DESCRIPTION
This PR removes the Docker compose version from the `docker-compose.yaml` files since they are obsoleted (thanks @remedcu for pointing this out).

I also added a `name` field, so that the name remains constant even if we move the docker compose files around (defaults to the parent directory name).