### PR TITLE
Fix `runOp` Script

### DIFF
--- a/modules/4337/package.json
+++ b/modules/4337/package.json
@@ -26,8 +26,9 @@
     "deploy": "hardhat deploy --network",
     "lint": "pnpm run lint:sol && npm run lint:ts",
     "lint:sol": "solhint 'contracts/**/*.sol'",
-    "lint:ts": "eslint ./src --fix && eslint ./test --fix",
-    "fmt": "prettier --write ./contracts/**/*.sol",
+    "lint:ts": "eslint ./src && eslint ./test",
+    "lint:fix": "eslint ./src --fix && eslint ./test --fix",
+    "fmt": "prettier --write .",
     "fmt:check": "prettier --check ./**/*.sol",
     "prepare": "pnpm run build"
   },


### PR DESCRIPTION
I was running the 4337 `runOp.ts` script this morning and noticed it was subtly broken. This PR fixes it.

I also refactored the scripts a bit - specifically we no longer `--fix` on `lint:ts`. This was because it would cause CI to silently pass in cases where the linter could autofix the code (when we want it to fail instead).