### PR TITLE
Check for Double Initialization

### DIFF
--- a/modules/4337/contracts/test/TestSafeSignerLaunchpad.sol
+++ b/modules/4337/contracts/test/TestSafeSignerLaunchpad.sol
@@ -96,6 +96,7 @@ contract TestSafeSignerLaunchpad is IAccount, SafeStorage {
     receive() external payable {}
 
     function preValidationSetup(bytes32 initHash, address to, bytes calldata preInit) external onlyProxy {
+        require(_initHash() == bytes32(0), "Already initialized");
         _setInitHash(initHash);
         if (to != address(0)) {
             (bool success, ) = to.delegatecall(preInit);


### PR DESCRIPTION
The test/example Safe signer launchpad pattern in the ERC-4337 module directory did not contain an important security check preventing double initialization which could lead to an account being taken over.

In order to better document the security requirements for such a contract, we added the double initialization check to the pre-validation setup.

Huge kudos to Ackee Blockchain for bringing this to our attention :muscle:.