### PR TITLE
Verify Contracts on Sourcify With Deployment

### DIFF
--- a/modules/passkey/README.md
+++ b/modules/passkey/README.md
@@ -94,8 +94,9 @@ This will perform the following steps
 ```bash
 pnpm run build
 npx hardhat --network $NETWORK deploy
-npx hardhat --network $NETWORK etherscan-verify
 npx hardhat --network $NETWORK local-verify
+npx hardhat --network $NETWORK etherscan-verify
+npx hardhat --network $NETWORK sourcify
 npx hardhat --network $NETWORK verify $SAFE_WEBAUTHN_SIGNER_SINGLETON_ADDRESS --contract SafeWebAuthnSignerSingleton
 ```
 

--- a/modules/passkey/src/tasks/deployContracts.ts
+++ b/modules/passkey/src/tasks/deployContracts.ts
@@ -4,6 +4,7 @@ task('deploy-contracts', 'Deploys and verifies Safe contracts').setAction(async 
   await run('deploy')
   await run('local-verify')
   await run('etherscan-verify', { forceLicense: true, license: 'LGPL-3.0' })
+  await run('sourcify')
 
   // The `SafeWebAuthnSignerSingleton` is deployed by the `SafeWebAuthnSignerFactory` contructor
   // and not by the deployment script, so it does not automatically get verified. We work around


### PR DESCRIPTION
The `deployContracts` task currently only verifies contracts on Etherscan on deployment, instead of Etherscan + Sourcify. This PR fixes the script to verify contract code on both.