### PR TITLE
Update Passkey Example for Release

### DIFF
--- a/examples/4337-passkeys/package.json
+++ b/examples/4337-passkeys/package.json
@@ -7,14 +7,16 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "lint:fix": "pnpm run lint -- --fix",
+    "lint:fix": "pnpm run lint --fix",
     "preview": "vite preview"
   },
   "dependencies": {
     "@account-abstraction/contracts": "0.7.0",
     "@safe-global/safe-4337": "0.3.0",
     "@safe-global/safe-contracts": "^1.4.1-build.0",
-    "@safe-global/safe-passkey": "workspace:0.2.0",
+    "@safe-global/safe-deployments": "^1.36.0",
+    "@safe-global/safe-modules-deployments": "^2.2.0",
+    "@safe-global/safe-passkey": "0.2.0",
     "@web3modal/ethers": "^4.1.11",
     "ethers": "^6.12.1",
     "react": "^18.3.1",

--- a/examples/4337-passkeys/src/config.ts
+++ b/examples/4337-passkeys/src/config.ts
@@ -1,3 +1,10 @@
+import { getMultiSendDeployment, getProxyFactoryDeployment, getSafeL2SingletonDeployment } from '@safe-global/safe-deployments'
+import {
+  getFCLP256VerifierDeployment,
+  getSafe4337ModuleDeployment,
+  getSafeModuleSetupDeployment,
+} from '@safe-global/safe-modules-deployments'
+
 // 11155111 = Sepolia testnet chain id
 const APP_CHAIN_ID = 11155111
 
@@ -5,24 +12,34 @@ const APP_CHAIN_ID = 11155111
 // https://eips.ethereum.org/EIPS/eip-3770
 const APP_CHAIN_SHORTNAME = 'sep'
 
+type DeploymentFunction = (filter: { network: string }) => { networkAddresses: Record<string, string | undefined> } | undefined
+function getDeploymentAddress(fn: DeploymentFunction) {
+  const network = `${APP_CHAIN_ID}`
+  const deployment = fn({ network })
+  if (!deployment || !deployment.networkAddresses[network]) {
+    throw new Error('deployment not found')
+  }
+  return deployment.networkAddresses[network]
+}
+
 /*
-  Some of the contracts used in the PoC app are still experimental, and not included in
-  the production deployment packages, thus we need to hardcode their addresses here.
-  Deployment commit: https://github.com/safe-global/safe-modules/commit/3853f34f31837e0a0aee47a4452564278f8c62ba
+  The Safe WebAuthn shared signer is still not audited and not included in the production deployment
+  packages, thus we need to hardcode their addresses here.
+  Deployment tag: https://github.com/safe-global/safe-modules/tree/passkey/v0.2.0
 */
-const SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS = '0x608Cf2e3412c6BDA14E6D8A0a7D27c4240FeD6F1'
+const SAFE_WEBAUTHN_SHARED_SIGNER_ADDRESS = '0xfD90FAd33ee8b58f32c00aceEad1358e4AFC23f9'
 
-const SAFE_MULTISEND_ADDRESS = '0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526'
+const SAFE_MULTISEND_ADDRESS = getDeploymentAddress(getMultiSendDeployment)
 
-const SAFE_4337_MODULE_ADDRESS = '0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226'
+const SAFE_4337_MODULE_ADDRESS = getDeploymentAddress(getSafe4337ModuleDeployment)
 
-const SAFE_MODULE_SETUP_ADDRESS = '0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47'
+const SAFE_MODULE_SETUP_ADDRESS = getDeploymentAddress(getSafeModuleSetupDeployment)
 
-const P256_VERIFIER_ADDRESS = '0xcA89CBa4813D5B40AeC6E57A30d0Eeb500d6531b' // FCLP256Verifier
+const P256_VERIFIER_ADDRESS = getDeploymentAddress(getFCLP256VerifierDeployment)
 
-const SAFE_PROXY_FACTORY_ADDRESS = '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67'
+const SAFE_PROXY_FACTORY_ADDRESS = getDeploymentAddress(getProxyFactoryDeployment)
 
-const SAFE_SINGLETON_ADDRESS = '0x29fcB43b46531BcA003ddC8FCB67FFE91900C762'
+const SAFE_SINGLETON_ADDRESS = getDeploymentAddress(getSafeL2SingletonDeployment)
 
 const ENTRYPOINT_ADDRESS = '0x0000000071727De22E5E9d8BAf0edAc6f37da032'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,15 @@ importers:
       '@safe-global/safe-contracts':
         specifier: ^1.4.1-build.0
         version: 1.4.1-build.0(ethers@6.12.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@safe-global/safe-deployments':
+        specifier: ^1.36.0
+        version: 1.36.0
+      '@safe-global/safe-modules-deployments':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@safe-global/safe-passkey':
-        specifier: workspace:0.2.0
-        version: link:../../modules/passkey
+        specifier: 0.2.0
+        version: 0.2.0(ethers@6.12.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@web3modal/ethers':
         specifier: ^4.1.11
         version: 4.2.2(@types/react@18.3.3)(bufferutil@4.0.8)(ethers@6.12.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10)
@@ -1299,6 +1305,12 @@ packages:
 
   '@safe-global/safe-deployments@1.36.0':
     resolution: {integrity: sha512-9MbDJveRR64AbmzjIpuUqmDBDtOZpXpvkyhTUs+5UOPT3WgSO375/ZTO7hZpywP7+EmxnjkGc9EoxjGcC4TAyw==}
+
+  '@safe-global/safe-modules-deployments@2.2.0':
+    resolution: {integrity: sha512-ZzNhMf8Xxods3TrY7kSrescnicHQRFH7eYx7TMKqVhxFScEiuYmivQMdV94ziF+Hot0xCcrrFeed657U/oXrJw==}
+
+  '@safe-global/safe-passkey@0.2.0':
+    resolution: {integrity: sha512-B9IpVvwXLvK3m+BRhn9z8kCbEizFmua4YmaUBZ9yr0xM9YsX2PRTnxbFvC7pLph1OQ2u+9O2V3FEmPiS10YEIw==}
 
   '@safe-global/safe-singleton-factory@1.0.26':
     resolution: {integrity: sha512-79xL013OAenMyQZLIDLzuRoO4z/nH3AHLG93PdD1RQltAP98QEoeMjGeWwOkLq26pLMM9OeFz4MPuWtZ2qxWmw==}
@@ -6105,6 +6117,17 @@ snapshots:
   '@safe-global/safe-deployments@1.36.0':
     dependencies:
       semver: 7.6.2
+
+  '@safe-global/safe-modules-deployments@2.2.0': {}
+
+  '@safe-global/safe-passkey@0.2.0(ethers@6.12.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@account-abstraction/contracts': 0.7.0
+      '@openzeppelin/contracts': 5.0.2
+      '@safe-global/safe-contracts': 1.4.1-build.0(ethers@6.12.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      cbor: 9.0.2
+    transitivePeerDependencies:
+      - ethers
 
   '@safe-global/safe-singleton-factory@1.0.26': {}
 


### PR DESCRIPTION
Now that we have released the passkey package, the 4337 example can be updated to use the released packages instead of the development code.

I also change the configuration to make use of the `*-deployments` packages to make sure the example works on the "real" addresses.

I manually ran the example application and was successful with creating and executing user operations:

- [Safe creation userOp](https://sepolia.etherscan.io/tx/0xdcab84d43b4bbd954c13fd991615c2490b0c6e59a058e46764d2875e6dbf4e4f)
- [Transfer userOp](https://sepolia.etherscan.io/tx/0x15210fb522c94907bc38bb99cc9b1020a20e32e19c517f8fed04f607c9c1d666)