### PR TITLE
Feature: 4337 module `v0.3.0-1`

### DIFF
--- a/modules/4337/package.json
+++ b/modules/4337/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-4337",
-  "version": "0.3.0",
+  "version": "0.3.0-1",
   "description": "Safe Module for ERC-4337 support",
   "homepage": "https://github.com/safe-global/safe-modules/tree/main/modules/4337",
   "license": "GPL-3.0",

--- a/modules/passkey/package.json
+++ b/modules/passkey/package.json
@@ -51,7 +51,7 @@
     "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@safe-global/mock-contract": "^4.1.0",
-    "@safe-global/safe-4337": "workspace:^0.3.0",
+    "@safe-global/safe-4337": "workspace:^0.3.0-1",
     "@safe-global/safe-4337-local-bundler": "workspace:^0.0.0",
     "@simplewebauthn/server": "^10.0.0",
     "@types/node": "^20.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,7 +313,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@safe-global/safe-4337':
-        specifier: workspace:^0.3.0
+        specifier: workspace:^0.3.0-1
         version: link:../4337
       '@safe-global/safe-4337-local-bundler':
         specifier: workspace:^0.0.0


### PR DESCRIPTION
This PR:
- Implements https://github.com/safe-global/safe-modules/issues/426 by releasing the code we have now under a new tag
- There were no contract changes, so the expected addresses are the same. I confirmed it by trying to deploy to a network where the contracts are already deployed:
```
> hardhat deploy-contracts --network "mainnet"

Nothing to compile
No need to generate any newer typings.
reusing "SafeModuleSetup" at 0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47
reusing "Safe4337Module" at 0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226
```