### PR TITLE
Index Signer In Created Event

### DIFF
--- a/modules/passkey/contracts/interfaces/ISafeSignerFactory.sol
+++ b/modules/passkey/contracts/interfaces/ISafeSignerFactory.sol
@@ -17,7 +17,7 @@ interface ISafeSignerFactory {
      * @param y The y-coordinate of the public key.
      * @param verifiers The P-256 verifiers to use.
      */
-    event Created(address signer, uint256 x, uint256 y, P256.Verifiers verifiers);
+    event Created(address indexed signer, uint256 x, uint256 y, P256.Verifiers verifiers);
 
     /**
      * @notice Gets the unique signer address for the specified data.


### PR DESCRIPTION
As discussed internally with the team, we decided to index the `signer` field of the `Created` event from the passkey factory contract. This came as a follow up to event discussions from an issue raised from the Hats audit competition: https://github.com/hats-finance/Safe-0x2909fdefd24a1ced675cb1444918fa766d76bdac/issues/3

Note that this only slightly increases the deployment costs:

```
=== BEFORE ===
  Gas Benchmarking [@bench]
    SafeWebAuthnSignerProxy
      ⛽ deployment: 94366
      ✔ Benchmark signer deployment cost (476ms)

=== AFTER  ===
  Gas Benchmarking [@bench]
    SafeWebAuthnSignerProxy
      ⛽ deployment: 94476
      ✔ Benchmark signer deployment cost (476ms)
```

For reference, this is a 0.1% increase to the deployment gas costs.