### PR TITLE
fix-correct-example-address

### DIFF
--- a/examples/4337-passkeys/README.md
+++ b/examples/4337-passkeys/README.md
@@ -8,7 +8,7 @@ This minimalistic example application demonstrates a Safe{Core} Smart Account de
 
 ```bash
 git clone https://github.com/safe-global/safe-modules.git
-cd safe-modules
+cd safe-modules/examples/4337-passkeys
 ```
 
 ### Install dependencies

--- a/examples/4337-passkeys/src/logic/userOp.ts
+++ b/examples/4337-passkeys/src/logic/userOp.ts
@@ -63,7 +63,7 @@ export function getSignatureBytes({
   // Helper functions
   // Convert a number to a 64-byte hex string with padded upto Hex string with 32 bytes
   const encodeUint256 = (x: bigint | number) => x.toString(16).padStart(64, '0')
-  // Calculate the byte size of the dynamic data along with the length parameter alligned to 32 bytes
+  // Calculate the byte size of the dynamic data along with the length parameter aligned to 32 bytes
   const byteSize = (data: Uint8Array) => 32 * (Math.ceil(data.length / 32) + 1) // +1 is for the length parameter
   // Encode dynamic data padded with zeros if necessary in 32 bytes chunks
   const encodeBytes = (data: Uint8Array) => `${encodeUint256(data.length)}${ethers.hexlify(data).slice(2)}`.padEnd(byteSize(data) * 2, '0')

--- a/examples/4337-passkeys/src/main.tsx
+++ b/examples/4337-passkeys/src/main.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 
-// Keep the import of the wallets file to eval so w3m package can initialise
+// Keep the import of the wallets file to eval so w3m package can initialize
 // the required globals
 import './logic/wallets.ts'
 import './index.css'


### PR DESCRIPTION
This PR fixes the directory in the README of the example 4337-passkeys. 

It also fixes two minor typos.