### PR TITLE
Emit Event on Shared Signer Configuration

### DIFF
--- a/modules/passkey/contracts/4337/SafeWebAuthnSharedSigner.sol
+++ b/modules/passkey/contracts/4337/SafeWebAuthnSharedSigner.sol
@@ -33,11 +33,6 @@ contract SafeWebAuthnSharedSigner is SignatureValidator {
     uint256 private constant _SIGNER_MAPPING_SLOT = 0x2e0aed53485dc2290ceb5ce14725558ad3e3a09d38c69042410ad15c2b4ea4e8;
 
     /**
-     * @notice An error indicating a `CALL` to a function that should only be `DELEGATECALL`-ed.
-     */
-    error NotDelegateCalled();
-
-    /**
      * @notice Address of the shared signer contract itself.
      * @dev This is used for determining whether or not the contract is being `DELEGATECALL`-ed when
      * setting signer data.
@@ -48,6 +43,23 @@ contract SafeWebAuthnSharedSigner is SignatureValidator {
      * @notice The starting storage slot on the account containing the signer data.
      */
     uint256 public immutable SIGNER_SLOT;
+
+    /**
+     * @notice Emitted when the shared signer is configured for an account.
+     * @dev Note that the configured account is not included in the event data. Since configuration
+     * is done as a `DELEGATECALL`, the contract emitting the event is the configured account. This
+     * is also why the event name is prefixed with `SafeWebAuthnSharedSigner`, in order to avoid
+     * event `topic0` collisions with other contracts (seeing as "configured" is a common term).
+     * @param x The x-coordinate of the public key.
+     * @param y The y-coordinate of the public key.
+     * @param verifiers The P-256 verifiers to use.
+     */
+    event SafeWebAuthnSharedSignerConfigured(uint256 x, uint256 y, P256.Verifiers verifiers);
+
+    /**
+     * @notice An error indicating a `CALL` to a function that should only be `DELEGATECALL`-ed.
+     */
+    error NotDelegateCalled();
 
     /**
      * @notice Create a new shared WebAuthn signer instance.
@@ -133,6 +145,8 @@ contract SafeWebAuthnSharedSigner is SignatureValidator {
         signerStorage.x = signer.x;
         signerStorage.y = signer.y;
         signerStorage.verifiers = signer.verifiers;
+
+        emit SafeWebAuthnSharedSignerConfigured(signer.x, signer.y, signer.verifiers);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/hats-finance/Safe-0x2909fdefd24a1ced675cb1444918fa766d76bdac/issues/3

This PR adds an event that is emitted on shared signer configuration. Note that the event is emitted in the context of the configured Safe account. In order to prevent event `topic0` collisions, we chose an explicitly verbose name.

With respect to indexing, we explicitly chose **not** to index any of the fields so that it matches the `Created` event:

https://github.com/safe-global/safe-modules/blob/bb5e1f7360633d5ecfb175c5d8667b2a3a1b746d/modules/passkey/contracts/interfaces/ISafeSignerFactory.sol#L13-L20

To re-iterate on the reasons we chose to not index some of the fields (same reasoning applies to `Created` event above):
- `x` and `y`: These are single-use public key coordinates attached to a passkey. It doesn't make sense to filter events by "all events with `x` value", or similarly "all events with `y` value". Furthermore, you can compute the `signer` (which is indexed in the `Created` event) from the key coordinates, so you can to some degree search for signers for a given key coordinate.
- `verifiers`: This felt more like a configuration than something that Dapps would need to filter by. Why it might be interesting to see on chain which verifiers are being used, tools like Dune can help with this, and the additional cost of an indexed field is not worth it in our opinion.