### PR TITLE
Add comment in _checkSignaturesLength regarding dynamic signatures

### DIFF
--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -223,9 +223,9 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * `_checkSignaturesLength` function checks for the presence of any padded bytes to the `signature` data.
      * However, there is an edge case that `_checkSignaturesLength` function cannot detect.
      * A malicious bundler can manipulate the field(s) storing the signature length and pad additional bytes to the
-     * dynamic part of the signatures which will make `_checkSignaturesLength` to return true. In such cases, it is the
-     * responsibility of the Safe signature validator (which can be a Safe or any other contract) that supports
-     * ERC-1271 and is the owner of the Safe to check for additional bytes to it smart contract signature data.
+     * dynamic part of the signatures which will make `_checkSignaturesLength` to return true.  In such cases, it is
+     * the responsibility of the Safe signature validator implementation, as an account owner, to check for additional
+     * bytes to it smart contract signature data.
      * @param signatures Signatures data.
      * @param threshold Signer threshold for the Safe account.
      * @return isValid True if length check passes, false otherwise.

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -217,15 +217,16 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * of {checkSignatures}.
      * @dev Safe account has two types of signatures: EOA and Smart Contract signatures. While the EOA signature is 
      * fixed in size, the Smart Contract signature can be of arbitrary length. Safe encodes the Smart Contract
-     * signature length in the signature data. A malicious bundler can pad additional bytes to the `signature` data,
-     * causing the account to pay more gas than needed for user operation validation and reach the
-     * verificationGasLimit if the verifier does not implement appropriate length checks. `_checkSignaturesLength`
-     * function checks for presence of any padded bytes to the `signature` data. However, there is an
-     * edge case that `_checkSignaturesLength` function cannot detect. Since, the `signature` field in UserOp is not
-     * part of the UserOp hash a malicious bundler can manipulate the field storing the signature length and pad
-     * additional bytes to the dynamic part of the signatures which will make `_checkSignaturesLength` to return true.
-     * In such cases, it is the responsibility of the signature verifier to check for additional padded bytes to the
-     * signatures data.
+     * signature length in the signature data. If appropriate length checks are not performed during the signature
+     * verification then a malicious bundler can pad additional bytes to the signatures data and make the account pay
+     * more gas than needed for user operation validation and reach the verificationGasLimit.
+     * `_checkSignaturesLength` function checks for the presence of any padded bytes to the `signature` data.
+     * However, there is an edge case that `_checkSignaturesLength` function cannot detect.
+     * Since the `signature` field in UserOp is not part of the UserOp hash a malicious bundler can manipulate the
+     * field(s) storing the signature length and pad additional bytes to the dynamic part of the signatures which will
+     * make `_checkSignaturesLength` to return true. In such cases, it is the responsibility of the signature verifier
+     * (which can be a Safe or any other contract) that supports ERC-1271 and is the owner of the Safe to check for
+     * additional padded bytes to the signatures data.
      * @param signatures Signatures data.
      * @param threshold Signer threshold for the Safe account.
      * @return isValid True if length check passes, false otherwise.

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -222,11 +222,10 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * more gas than needed for user operation validation and reach the `verificationGasLimit`.
      * `_checkSignaturesLength` function checks for the presence of any padded bytes to the `signature` data.
      * However, there is an edge case that `_checkSignaturesLength` function cannot detect.
-     * Since the `signature` field in UserOp is not part of the UserOp hash a malicious bundler can manipulate the
-     * field(s) storing the signature length and pad additional bytes to the dynamic part of the signatures which will
-     * make `_checkSignaturesLength` to return true. In such cases, it is the responsibility of the Safe signature validator
-     * (which can be a Safe or any other contract) that supports ERC-1271 and is the owner of the Safe to check for
-     * additional bytes to it smart contract signature data.
+     * A malicious bundler can manipulate the field(s) storing the signature length and pad additional bytes to the
+     * dynamic part of the signatures which will make `_checkSignaturesLength` to return true. In such cases, it is the
+     * responsibility of the Safe signature validator (which can be a Safe or any other contract) that supports
+     * ERC-1271 and is the owner of the Safe to check for additional bytes to it smart contract signature data.
      * @param signatures Signatures data.
      * @param threshold Signer threshold for the Safe account.
      * @return isValid True if length check passes, false otherwise.

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -219,7 +219,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * fixed in size, the Smart Contract signature can be of arbitrary length. Safe encodes the Smart Contract
      * signature length in the signature data. If appropriate length checks are not performed during the signature
      * verification then a malicious bundler can pad additional bytes to the signatures data and make the account pay
-     * more gas than needed for user operation validation and reach the verificationGasLimit.
+     * more gas than needed for user operation validation and reach the `verificationGasLimit`.
      * `_checkSignaturesLength` function checks for the presence of any padded bytes to the `signature` data.
      * However, there is an edge case that `_checkSignaturesLength` function cannot detect.
      * Since the `signature` field in UserOp is not part of the UserOp hash a malicious bundler can manipulate the

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -224,7 +224,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * However, there is an edge case that `_checkSignaturesLength` function cannot detect.
      * Since the `signature` field in UserOp is not part of the UserOp hash a malicious bundler can manipulate the
      * field(s) storing the signature length and pad additional bytes to the dynamic part of the signatures which will
-     * make `_checkSignaturesLength` to return true. In such cases, it is the responsibility of the signature verifier
+     * make `_checkSignaturesLength` to return true. In such cases, it is the responsibility of the Safe signature validator
      * (which can be a Safe or any other contract) that supports ERC-1271 and is the owner of the Safe to check for
      * additional padded bytes to the signatures data.
      * @param signatures Signatures data.

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -212,9 +212,17 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
     }
 
     /**
-     * @dev Checks if the signatures length is correct and does not contain additional bytes. The function does not
+     * @notice Checks if the signatures length is correct and does not contain additional bytes. The function does not
      * check the integrity of the signature encoding, as this is expected to be checked by the {Safe} implementation
      * of {checkSignatures}.
+     * @dev A malicious bundler can pad additional bytes to the `signatures` data, causing the account to pay more gas
+     * than needed for user operation validation. Safe account has two types of signatures: EOA and Smart Contract
+     * signatures. While the EOA signature is fixed in size, the Smart Contract signature can be of arbitrary length.
+     * Safe encodes the Smart Contract signature length in the signature data. Since, the `signature` field in UserOp
+     * is not part of the UserOp hash a malicious bundler can manipulate the field storing the signature length and pad
+     * additional bytes to the dynamic part of the signatures which will make `_checkSignaturesLength` to return true.
+     * In such cases, it is the responsibility of the signature verifier to check for additional padded bytes to the
+     * signatures data.
      * @param signatures Signatures data.
      * @param threshold Signer threshold for the Safe account.
      * @return isValid True if length check passes, false otherwise.

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -228,7 +228,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * A malicious bundler can manipulate the field(s) storing the signature length and pad additional bytes to the
      * dynamic part of the signatures which will make `_checkSignaturesLength` to return true.  In such cases, it is
      * the responsibility of the Safe signature validator implementation, as an account owner, to check for additional
-     * bytes to it smart contract signature data.
+     * bytes.
      * @param signatures Signatures data.
      * @param threshold Signer threshold for the Safe account.
      * @return isValid True if length check passes, false otherwise.

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -215,7 +215,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @notice Checks if the signatures length is correct and does not contain additional bytes. The function does not
      * check the integrity of the signature encoding, as this is expected to be checked by the {Safe} implementation
      * of {checkSignatures}.
-     * @dev Safe account has two types of signatures: EOA and Smart Contract signatures. While the EOA signature is 
+     * @dev Safe account has two types of signatures: EOA and Smart Contract signatures. While the EOA signature is
      * fixed in size, the Smart Contract signature can be of arbitrary length. Safe encodes the Smart Contract
      * signature length in the signature data. If appropriate length checks are not performed during the signature
      * verification then a malicious bundler can pad additional bytes to the signatures data and make the account pay

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -215,11 +215,14 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * @notice Checks if the signatures length is correct and does not contain additional bytes. The function does not
      * check the integrity of the signature encoding, as this is expected to be checked by the {Safe} implementation
      * of {checkSignatures}.
-     * @dev A malicious bundler can pad additional bytes to the `signatures` data, causing the account to pay more gas
-     * than needed for user operation validation. Safe account has two types of signatures: EOA and Smart Contract
-     * signatures. While the EOA signature is fixed in size, the Smart Contract signature can be of arbitrary length.
-     * Safe encodes the Smart Contract signature length in the signature data. Since, the `signature` field in UserOp
-     * is not part of the UserOp hash a malicious bundler can manipulate the field storing the signature length and pad
+     * @dev Safe account has two types of signatures: EOA and Smart Contract signatures. While the EOA signature is 
+     * fixed in size, the Smart Contract signature can be of arbitrary length. Safe encodes the Smart Contract
+     * signature length in the signature data. A malicious bundler can pad additional bytes to the `signature` data,
+     * causing the account to pay more gas than needed for user operation validation and reach the
+     * verificationGasLimit if the verifier does not implement appropriate length checks. `_checkSignaturesLength`
+     * function checks for presence of any padded bytes to the `signature` data. However, there is an
+     * edge case that `_checkSignaturesLength` function cannot detect. Since, the `signature` field in UserOp is not
+     * part of the UserOp hash a malicious bundler can manipulate the field storing the signature length and pad
      * additional bytes to the dynamic part of the signatures which will make `_checkSignaturesLength` to return true.
      * In such cases, it is the responsibility of the signature verifier to check for additional padded bytes to the
      * signatures data.

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -216,12 +216,13 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * check the integrity of the signature encoding, as this is expected to be checked by the {Safe} implementation
      * of {checkSignatures}.
      * @dev Safe account has two types of signatures: EOA and Smart Contract signatures. While the EOA signature is
-     * fixed in size, the Smart Contract signature can be of arbitrary length. Safe encodes the Smart Contract
-     * signature length in the signature data. If appropriate length checks are not performed during the signature
-     * verification then a malicious bundler can pad additional bytes to the signatures data and make the account pay
-     * more gas than needed for user operation validation and reach the `verificationGasLimit`.
-     * `_checkSignaturesLength` function checks for the presence of any padded bytes to the `signature` data.
-     * However, there is an edge case that `_checkSignaturesLength` function cannot detect.
+     * fixed in size, the Smart Contract signature can be of arbitrary length. If appropriate length checks are not
+     * performed during the signature verification then a malicious bundler can pad additional bytes to the signatures
+     * data and make the account pay more gas than needed for user operation validation and reach the
+     * `verificationGasLimit`. `_checkSignaturesLength` function checks for the presence of any padded bytes to the
+     * `signature` data. However, there is an edge case that `_checkSignaturesLength` function cannot detect.
+     * Signatures data for Smart Contracts contains a dynamic part that is encoded as:
+     *     {32-bytes signature length}{bytes signature data}
      * A malicious bundler can manipulate the field(s) storing the signature length and pad additional bytes to the
      * dynamic part of the signatures which will make `_checkSignaturesLength` to return true.  In such cases, it is
      * the responsibility of the Safe signature validator implementation, as an account owner, to check for additional

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -226,7 +226,7 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * field(s) storing the signature length and pad additional bytes to the dynamic part of the signatures which will
      * make `_checkSignaturesLength` to return true. In such cases, it is the responsibility of the Safe signature validator
      * (which can be a Safe or any other contract) that supports ERC-1271 and is the owner of the Safe to check for
-     * additional padded bytes to the signatures data.
+     * additional bytes to it smart contract signature data.
      * @param signatures Signatures data.
      * @param threshold Signer threshold for the Safe account.
      * @return isValid True if length check passes, false otherwise.

--- a/modules/4337/contracts/Safe4337Module.sol
+++ b/modules/4337/contracts/Safe4337Module.sol
@@ -219,8 +219,10 @@ contract Safe4337Module is IAccount, HandlerContext, CompatibilityFallbackHandle
      * fixed in size, the Smart Contract signature can be of arbitrary length. If appropriate length checks are not
      * performed during the signature verification then a malicious bundler can pad additional bytes to the signatures
      * data and make the account pay more gas than needed for user operation validation and reach the
-     * `verificationGasLimit`. `_checkSignaturesLength` function checks for the presence of any padded bytes to the
-     * `signature` data. However, there is an edge case that `_checkSignaturesLength` function cannot detect.
+     * `verificationGasLimit`. _checkSignaturesLength ensures that the signatures data cannot be longer than the
+     * canonical encoding of Safe signatures, thus setting a strict upper bound on how long the signatures bytes can
+     * be, greatly limiting a malicious bundler's ability to pad signature bytes. However, there is an edge case that
+     * `_checkSignaturesLength` function cannot detect.
      * Signatures data for Smart Contracts contains a dynamic part that is encoded as:
      *     {32-bytes signature length}{bytes signature data}
      * A malicious bundler can manipulate the field(s) storing the signature length and pad additional bytes to the


### PR DESCRIPTION
This PR adds a comment on dynamic signatures and signature length manipulation in `_checkSignaturesLength` Natspec