### PR TITLE
Use Arachnid CREATE2 Deployer For Some Contracts

### DIFF
--- a/modules/passkey/CHANGELOG.md
+++ b/modules/passkey/CHANGELOG.md
@@ -13,11 +13,8 @@ EVM target: Paris
 
 - `SafeWebAuthnSignerFactory` at `0x1d31F259eE307358a26dFb23EB365939E8641195`
 - `SafeWebAuthnSharedSigner` at `0x94a4F6affBd8975951142c3999aEAB7ecee555c2`
+- `DaimoP256Verifier` at `0xc2b78104907F722DABAc4C69f826a522B2754De4` ([source](https://p256.eth.limo/))
 - `FCLP256Verifier` at `0xA86e0054C51E4894D88762a017ECc5E5235f5DBA`
-
-### Official Deployment Address from 3rd party
-
-- `DaimoP256Verifier` at `0xc2b78104907F722DABAc4C69f826a522B2754De4` ([Source](https://p256.eth.limo/))
 
 ## Changes
 

--- a/modules/passkey/src/deploy/verifiers.ts
+++ b/modules/passkey/src/deploy/verifiers.ts
@@ -1,24 +1,43 @@
+import type { HardhatRuntimeEnvironment } from 'hardhat/types'
 import type { DeployFunction } from 'hardhat-deploy/types'
 
 import DaimoP256Verifier from '../vendor/daimo-eth/P256Verifier.json'
 
-const deploy: DeployFunction = async ({ deployments, getNamedAccounts }) => {
+const deploy: DeployFunction = async (hre) => {
+  const { deployments, getNamedAccounts } = hre
+
   const { deployer } = await getNamedAccounts()
   const { deploy } = deployments
 
-  await deploy('DaimoP256Verifier', {
-    from: deployer,
-    contract: DaimoP256Verifier,
-    args: [],
-    deterministicDeployment: true,
-    log: true,
-  })
+  // The official Daimo P-256 verifier contract is deployed using the Arachnid CREATE2 deployer.
+  await withArachnidDeterministicDeploymentProxy(hre, () =>
+    deploy('DaimoP256Verifier', {
+      from: deployer,
+      contract: DaimoP256Verifier,
+      args: [],
+      deterministicDeployment: true,
+      log: true,
+    }),
+  )
 
   await deploy('FCLP256Verifier', {
     from: deployer,
     args: [],
     deterministicDeployment: true,
     log: true,
+  })
+}
+
+function withArachnidDeterministicDeploymentProxy<T>({ config }: HardhatRuntimeEnvironment, f: () => Promise<T>): Promise<T> {
+  // This is a bit hacky - but the `hardhat-deploy` package reads that deterministic deployment
+  // configuration before deploying each contract. This means that we can temporarily override the
+  // the configuration to `undefined` so that it uses the (default) Arachnid deterministic
+  // deployment proxy for a specific deployment, and then restore the configuration afterwards so
+  // that remaining contracts use the deterministic deployment factory from `hardhat.config.ts`.
+  const existingConfig = config.deterministicDeployment
+  config.deterministicDeployment = undefined
+  return f().finally(() => {
+    config.deterministicDeployment = existingConfig
   })
 }
 

--- a/packages/4337-local-bundler/src/deploy/entrypoint.ts
+++ b/packages/4337-local-bundler/src/deploy/entrypoint.ts
@@ -1,7 +1,9 @@
 import EntryPoint from '@account-abstraction/contracts/artifacts/EntryPoint.json'
-import { DeployFunction } from 'hardhat-deploy/types'
+import type { HardhatRuntimeEnvironment } from 'hardhat/types'
+import type { DeployFunction } from 'hardhat-deploy/types'
 
-const deploy: DeployFunction = async ({ deployments, getNamedAccounts, network }) => {
+const deploy: DeployFunction = async (hre) => {
+  const { deployments, getNamedAccounts, network } = hre
   if (!network.tags.entrypoint) {
     return
   }
@@ -9,12 +11,28 @@ const deploy: DeployFunction = async ({ deployments, getNamedAccounts, network }
   const { deployer } = await getNamedAccounts()
   const { deploy } = deployments
 
-  await deploy('EntryPoint', {
-    from: deployer,
-    contract: EntryPoint,
-    args: [],
-    log: true,
-    deterministicDeployment: '0x90d8084deab30c2a37c45e8d47f49f2f7965183cb6990a98943ef94940681de3',
+  // The official ERC-4337 entry point contract is deployed using the Arachnid CREATE2 deployer.
+  await withArachnidDeterministicDeploymentProxy(hre, () =>
+    deploy('EntryPoint', {
+      from: deployer,
+      contract: EntryPoint,
+      args: [],
+      log: true,
+      deterministicDeployment: '0x90d8084deab30c2a37c45e8d47f49f2f7965183cb6990a98943ef94940681de3',
+    }),
+  )
+}
+
+function withArachnidDeterministicDeploymentProxy<T>({ config }: HardhatRuntimeEnvironment, f: () => Promise<T>): Promise<T> {
+  // This is a bit hacky - but the `hardhat-deploy` package reads that deterministic deployment
+  // configuration before deploying each contract. This means that we can temporarily override the
+  // the configuration to `undefined` so that it uses the (default) Arachnid deterministic
+  // deployment proxy for a specific deployment, and then restore the configuration afterwards so
+  // that remaining contracts use the deterministic deployment factory from `hardhat.config.ts`.
+  const existingConfig = config.deterministicDeployment
+  config.deterministicDeployment = undefined
+  return f().finally(() => {
+    config.deterministicDeployment = existingConfig
   })
 }
 


### PR DESCRIPTION
Fixes #481

Some contracts included in our deployment script are expected to use the Arachnid CREATE deployment proxy instead of the Safe singleton factory. We change our deployment scripts to manually use the Arachnid CREATE2 deployer in those specific cases, so the contracts end up at the expected addresses.

Affected contracts:
- ERC-4337 entry point
- Daimo P-256 verifier

You can verify this works by running `pnpm run deploy hardhat` in the Passkey package and checking the deployment addresses are what you expect them to be:

```
...
deploying "EntryPoint" (tx: 0x58b5726a3381344205508251ec394b4bf74b6f8bc669be0b1c9de8d75ce1f8ef)...: deployed at 0x0000000071727De22E5E9d8BAf0edAc6f37da032 with 3650209 gas
...
deploying "DaimoP256Verifier" (tx: 0xe18ff421fb23f117cdb2e60917f68703459743d0a26a14b79eae2cc01def4a20)...: deployed at 0xc2b78104907F722DABAc4C69f826a522B2754De4 with 814337 gas
...
deploying "SafeWebAuthnSignerFactory" (tx: 0x3e6df468f44301ff0bd64fd2403a42214417e25eb865a3c8cb68c79cc5ce042f)...: deployed at 0x1d31F259eE307358a26dFb23EB365939E8641195 with 1031063 gas
deploying "SafeWebAuthnSharedSigner" (tx: 0xc9d5201f64e0f0d537870bafb8a6445c70970f3a13fdda763eee0cb0519bfbf9)...: deployed at 0x94a4F6affBd8975951142c3999aEAB7ecee555c2 with 690536 gas
```