### PR TITLE
Fix EIP-7212 Dev Node Docker Build

### DIFF
--- a/modules/passkey/docker/geth/Dockerfile
+++ b/modules/passkey/docker/geth/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/library/golang:latest AS builder
+FROM docker.io/library/golang:1.22 AS builder
 
 # The Geth fork that was easiest to get running with the RIP-7212
 # precompile was the Optimism Geth node. Note that we still need to apply a
 # small patch, as the precompile is only enabled with Optimism consensus which
 # is not enabled in Dev mode.
-RUN git clone --depth 1 --branch v1.101315.1 https://github.com/ethereum-optimism/op-geth /src
+RUN git clone --depth 1 --branch v1.101315.3 https://github.com/ethereum-optimism/op-geth /src
 
 WORKDIR /src
 COPY docker/geth/geth.patch .

--- a/modules/passkey/docker/geth/geth.patch
+++ b/modules/passkey/docker/geth/geth.patch
@@ -1,12 +1,13 @@
 diff --git a/params/config.go b/params/config.go
-index b3a96a96a..166243692 100644
+index bd5c40b..f56aa79 100644
 --- a/params/config.go
 +++ b/params/config.go
-@@ -1078,6 +1078,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules
+@@ -1122,7 +1122,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules
  		IsOptimismBedrock:  isMerge && c.IsOptimismBedrock(num),
  		IsOptimismRegolith: isMerge && c.IsOptimismRegolith(timestamp),
  		IsOptimismCanyon:   isMerge && c.IsOptimismCanyon(timestamp),
 -		IsOptimismFjord:    isMerge && c.IsOptimismFjord(timestamp),
 +		IsOptimismFjord:    c.IsFjord(timestamp),
+ 		IsOptimismGranite:  isMerge && c.IsOptimismGranite(timestamp),
  	}
  }


### PR DESCRIPTION
The docker build for the Optimism version of Geth with 7212 support was failing in CI. It turns out that this is related to a recent release of Go 1.23 which is causing Ethereum Geth and forks (such as the Optimism fork we use) to not build.

The fix it to pin to an older version of Golang (1.22 being the latest version that works). I also, in experimenting, updated the version of Optimism Geth we use to see if it would help - which it didn't, but decided to leave the change in anyhow (it is just a version bump to the source that we use to build and a small change to the patch file to account for the changed code).