### PR TITLE
Update Certora Version for 4337 Module

### DIFF
--- a/modules/4337/certora/requirements.txt
+++ b/modules/4337/certora/requirements.txt
@@ -1,1 +1,1 @@
-certora-cli==7.14.3
+certora-cli==7.20.3


### PR DESCRIPTION
Closes #472

This pull request includes a small change to the `modules/4337/certora/requirements.txt` file. The change updates the version of `certora-cli` from 7.14.3 to 7.20.3.