### PR TITLE
Increase test coverage for AllowanceModule

### DIFF
--- a/modules/allowances/test/allowanceManagement.spec.ts
+++ b/modules/allowances/test/allowanceManagement.spec.ts
@@ -27,7 +27,7 @@ describe('AllowanceModule allowanceManagement', () => {
     await expect(allowanceModule.connect(owner).addDelegate(collidingDelegateAddress)).to.be.revertedWith('currentDelegate == delegate')
   })
 
-  it('setAllowance reverts when delegate address equals address(0)', async () => {
+  it('Cannot set allowance for address(0)', async () => {
     const { token, allowanceModule } = await setupTests()
 
     const tokenAddress = await token.getAddress()
@@ -35,7 +35,7 @@ describe('AllowanceModule allowanceManagement', () => {
     await expect(allowanceModule.setAllowance(ZeroAddress, tokenAddress, 0, 0, 0)).to.be.revertedWith('delegate != address(0)')
   })
 
-  it('addDelegate reverts when delegate address equals address(0)', async () => {
+  it('Delegate address cannot be address(0)', async () => {
     const { allowanceModule } = await setupTests()
 
     await expect(allowanceModule.addDelegate(ZeroAddress)).to.be.revertedWith('index != uint(0)')
@@ -166,7 +166,6 @@ describe('AllowanceModule allowanceManagement', () => {
     const { safe, allowanceModule, owner, alice, bob, charlie } = await setupTests()
 
     const safeAddress = await safe.getAddress()
-    const allowanceAddress = await allowanceModule.getAddress()
 
     // add alice as delegate
     await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
@@ -183,7 +182,7 @@ describe('AllowanceModule allowanceManagement', () => {
     expect(next).to.equal(0)
   })
 
-  it('Save allowances even after removing delegate', async () => {
+  it('Explicitly save allowances even after removing delegate', async () => {
     const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
 
     const safeAddress = await safe.getAddress()
@@ -325,7 +324,7 @@ describe('AllowanceModule allowanceManagement', () => {
     expect(newNonce).to.equal(2)
   })
 
-  it('Add and reset allowance', async () => {
+  it('Reset allowance', async () => {
     const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
 
     const safeAddress = await safe.getAddress()
@@ -370,7 +369,7 @@ describe('AllowanceModule allowanceManagement', () => {
     expect(await token.balanceOf(bob.address)).to.equal(1000)
   })
 
-  it('Add and delete allowance', async () => {
+  it('Delete allowance', async () => {
     const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
 
     const safeAddress = await safe.getAddress()
@@ -478,7 +477,7 @@ describe('AllowanceModule allowanceManagement', () => {
     expect(await paymentToken.balanceOf(safeAddress)).to.equal(800)
   })
 
-  it('Revert when sum(payment, transfer amount) exceeds allowance amount', async () => {
+  it('Revert when total of payment and transfer amount exceeds allowance', async () => {
     const { safe, allowanceModule, token, owner, alice, bob, charlie } = await setupTests()
 
     const safeAddress = await safe.getAddress()

--- a/modules/allowances/test/allowanceManagement.spec.ts
+++ b/modules/allowances/test/allowanceManagement.spec.ts
@@ -3,10 +3,65 @@ import execAllowanceTransfer from './test-helpers/execAllowanceTransfer'
 import execSafeTransaction from './test-helpers/execSafeTransaction'
 import setup from './test-helpers/setup'
 import { deployments } from 'hardhat'
+import hre from 'hardhat'
+import { ZeroAddress } from 'ethers'
 
 describe('AllowanceModule allowanceManagement', () => {
   const setupTests = deployments.createFixture(async ({ deployments }) => {
     return setup(deployments)
+  })
+
+  it('Revert when delegate addresses collide', async () => {
+    const { safe, allowanceModule, owner, alice, bob } = await setupTests()
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    const collidingDelegateAddress = hre.ethers.getAddress(`0x${bob.address.slice(2, -12)}${alice.address.slice(-12)}`.toLowerCase())
+
+    await expect(
+      execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(collidingDelegateAddress), owner),
+    ).to.be.revertedWith('GS013')
+
+    await allowanceModule.connect(owner).addDelegate(alice.address)
+    await expect(allowanceModule.connect(owner).addDelegate(collidingDelegateAddress)).to.be.revertedWith('currentDelegate == delegate')
+  })
+
+  it('setAllowance reverts when delegate address equals address(0)', async () => {
+    const { token, allowanceModule } = await setupTests()
+
+    const tokenAddress = await token.getAddress()
+
+    await expect(allowanceModule.setAllowance(ZeroAddress, tokenAddress, 0, 0, 0)).to.be.revertedWith('delegate != address(0)')
+  })
+
+  it('addDelegate reverts when delegate address equals address(0)', async () => {
+    const { allowanceModule } = await setupTests()
+
+    await expect(allowanceModule.addDelegate(ZeroAddress)).to.be.revertedWith('index != uint(0)')
+  })
+
+  it('Do not emit event if delegate already added', async () => {
+    const { safe, allowanceModule, owner, alice } = await setupTests()
+
+    // add alice as delegate
+    await expect(await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner))
+      .to.emit(allowanceModule, 'AddDelegate')
+      .withArgs(safe.target, alice.address)
+
+    // add alice as delegate again
+    await expect(await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)).to.not.emit(
+      allowanceModule,
+      'AddDelegate',
+    )
+  })
+
+  it("Do not emit event if delegate doesn't exist when removing", async () => {
+    const { safe, allowanceModule, owner, alice } = await setupTests()
+
+    await expect(
+      await execSafeTransaction(safe, await allowanceModule.removeDelegate.populateTransaction(alice.address, false), owner),
+    ).to.not.emit(allowanceModule, 'AddDelegate')
   })
 
   it('Add delegates and removes first delegate', async () => {
@@ -134,5 +189,191 @@ describe('AllowanceModule allowanceManagement', () => {
 
     expect(1000).to.equal(await token.balanceOf(safeAddress))
     expect(0).to.equal(await token.balanceOf(bob.address))
+  })
+
+  it('Add and reset allowance', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // add allowance
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 500, 0, 0), owner)
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+
+    await execAllowanceTransfer(allowanceModule, {
+      safe: safeAddress,
+      token: tokenAddress,
+      to: bob.address,
+      amount: 500,
+      spender: alice,
+    })
+
+    expect(await token.balanceOf(safeAddress)).to.equal(500)
+    expect(await token.balanceOf(bob.address)).to.equal(500)
+
+    // reset alice's allowance
+    await expect(
+      await execSafeTransaction(safe, await allowanceModule.resetAllowance.populateTransaction(alice.address, tokenAddress), owner),
+    )
+      .to.emit(allowanceModule, 'ResetAllowance')
+      .withArgs(safeAddress, alice.address, tokenAddress)
+
+    await execAllowanceTransfer(allowanceModule, {
+      safe: safeAddress,
+      token: tokenAddress,
+      to: bob.address,
+      amount: 500,
+      spender: alice,
+    })
+
+    expect(await token.balanceOf(safeAddress)).to.equal(0)
+    expect(await token.balanceOf(bob.address)).to.equal(1000)
+  })
+
+  it('Add and delete allowance', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // add allowance
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 500, 0, 0), owner)
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+
+    // delete alice's allowance
+    await expect(
+      await execSafeTransaction(safe, await allowanceModule.deleteAllowance.populateTransaction(alice.address, tokenAddress), owner),
+    )
+      .to.emit(allowanceModule, 'DeleteAllowance')
+      .withArgs(safeAddress, alice.address, tokenAddress)
+
+    // does not work without an allowance
+    await expect(
+      execAllowanceTransfer(allowanceModule, {
+        safe: safeAddress,
+        token: tokenAddress,
+        to: bob.address,
+        amount: 500,
+        spender: alice,
+      }),
+    ).to.be.revertedWith('newSpent > allowance.spent && newSpent <= allowance.amount')
+
+    expect(await token.balanceOf(safeAddress)).to.equal(1000)
+    expect(await token.balanceOf(bob.address)).to.equal(0)
+  })
+
+  it('Use allowance with payment in same token', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob, charlie } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // add allowance
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+    expect(0).to.equal(await token.balanceOf(charlie.address))
+
+    await execAllowanceTransfer(allowanceModule.connect(charlie), {
+      safe: safeAddress,
+      token: tokenAddress,
+      to: bob.address,
+      amount: 99,
+      spender: alice,
+      paymentToken: tokenAddress,
+      payment: 1,
+    })
+
+    expect(await token.balanceOf(safeAddress)).to.equal(900)
+    expect(await token.balanceOf(bob.address)).to.equal(99)
+    expect(await token.balanceOf(charlie.address)).to.equal(1)
+  })
+
+  it('Use allowance with payment in different token', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob, charlie } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+    const paymentToken = await (await hre.ethers.getContractFactory('TestToken')).deploy()
+    await paymentToken.mint(safeAddress, 1000)
+    const paymentTokenAddress = await paymentToken.getAddress()
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // add allowance
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+    // add allowance for payment in native token
+    await execSafeTransaction(
+      safe,
+      await allowanceModule.setAllowance.populateTransaction(alice.address, paymentTokenAddress, 200, 0, 0),
+      owner,
+    )
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+    expect(0).to.equal(await paymentToken.balanceOf(charlie.address))
+
+    await execAllowanceTransfer(allowanceModule.connect(charlie), {
+      safe: safeAddress,
+      token: tokenAddress,
+      to: bob.address,
+      amount: 99,
+      spender: alice,
+      paymentToken: paymentTokenAddress,
+      payment: 200,
+    })
+
+    expect(await token.balanceOf(safeAddress)).to.equal(901)
+    expect(await token.balanceOf(bob.address)).to.equal(99)
+    expect(await paymentToken.balanceOf(safeAddress)).to.equal(800)
+  })
+
+  it('Revert when sum(payment, transfer amount) exceeds allowance amount', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob, charlie } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // add allowance
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+    expect(0).to.equal(await token.balanceOf(charlie.address))
+
+    await expect(
+      execAllowanceTransfer(allowanceModule.connect(charlie), {
+        safe: safeAddress,
+        token: tokenAddress,
+        to: bob.address,
+        amount: 100,
+        spender: alice,
+        paymentToken: tokenAddress,
+        payment: 1,
+      }),
+    ).to.be.revertedWith('newSpent > paymentAllowance.spent && newSpent <= paymentAllowance.amount')
+
+    expect(await token.balanceOf(safeAddress)).to.equal(1000)
+    expect(await token.balanceOf(bob.address)).to.equal(0)
+    expect(await token.balanceOf(charlie.address)).to.equal(0)
   })
 })

--- a/modules/allowances/test/allowanceSingle.spec.ts
+++ b/modules/allowances/test/allowanceSingle.spec.ts
@@ -91,6 +91,239 @@ describe('AllowanceModule allowanceSingle', () => {
     expect(2).to.equal(nonce)
   })
 
+  it('Execute allowance with delegate and empty signature', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+    const allowanceAddress = await allowanceModule.getAddress()
+
+    expect(await safe.isModuleEnabled(allowanceAddress)).to.equal(true)
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+
+    // ensure delegates are well configured
+    const { results } = await allowanceModule.getDelegates(safeAddress, 0, 10)
+    expect(results).to.deep.equal([alice.address])
+
+    // ensure tokens from allowances are correct
+    expect(await allowanceModule.getTokens(safeAddress, alice.address)).to.deep.equal([tokenAddress])
+
+    // load an existing allowance
+    let [amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+    expect(100).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.not.equal(lastReset) // this should be set to init time
+    expect(1).to.equal(nonce)
+
+    // load an non existing allowance - bob has none
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, bob.address, tokenAddress)
+    expect(0).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.equal(lastReset)
+    expect(0).to.equal(nonce)
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(alice.address))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+
+    await allowanceModule.connect(alice).executeAllowanceTransfer(safe, token, bob.address, 60, ZeroAddress, 0, alice.address, '0x')
+
+    expect(940).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(alice.address))
+    expect(60).to.equal(await token.balanceOf(bob.address))
+
+    // load Alice's Allowance
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+
+    // expect the last transfer to be reflected
+    expect(100).to.equal(amount)
+    expect(60).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(lastReset > 0).to.be.true
+    expect(2).to.equal(nonce)
+
+    // remove Alice's as spender
+    await execSafeTransaction(safe, await allowanceModule.removeDelegate.populateTransaction(alice.address, true), owner)
+
+    // load Alice's Allowance after delegate removal
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+
+    // everything zeroed, except nonce
+    expect(0).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.equal(lastReset)
+    expect(2).to.equal(nonce)
+  })
+
+  it('Execute allowance with v=1 in signature', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+    const allowanceAddress = await allowanceModule.getAddress()
+
+    expect(await safe.isModuleEnabled(allowanceAddress)).to.equal(true)
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+
+    // ensure delegates are well configured
+    const { results } = await allowanceModule.getDelegates(safeAddress, 0, 10)
+    expect(results).to.deep.equal([alice.address])
+
+    // ensure tokens from allowances are correct
+    expect(await allowanceModule.getTokens(safeAddress, alice.address)).to.deep.equal([tokenAddress])
+
+    // load an existing allowance
+    let [amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+    expect(100).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.not.equal(lastReset) // this should be set to init time
+    expect(1).to.equal(nonce)
+
+    // load an non existing allowance - bob has none
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, bob.address, tokenAddress)
+    expect(0).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.equal(lastReset)
+    expect(0).to.equal(nonce)
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(alice.address))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+
+    await allowanceModule
+      .connect(alice)
+      .executeAllowanceTransfer(safe, token, bob.address, 60, ZeroAddress, 0, alice.address, `0x${'00'.repeat(64)}01`)
+
+    expect(940).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(alice.address))
+    expect(60).to.equal(await token.balanceOf(bob.address))
+
+    // load Alice's Allowance
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+
+    // expect the last transfer to be reflected
+    expect(100).to.equal(amount)
+    expect(60).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(lastReset > 0).to.be.true
+    expect(2).to.equal(nonce)
+
+    // remove Alice's as spender
+    await execSafeTransaction(safe, await allowanceModule.removeDelegate.populateTransaction(alice.address, true), owner)
+
+    // load Alice's Allowance after delegate removal
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+
+    // everything zeroed, except nonce
+    expect(0).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.equal(lastReset)
+    expect(2).to.equal(nonce)
+  })
+
+  it('Execute allowance using eth_sign', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+    const allowanceAddress = await allowanceModule.getAddress()
+
+    expect(await safe.isModuleEnabled(allowanceAddress)).to.equal(true)
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+
+    // ensure delegates are well configured
+    const { results } = await allowanceModule.getDelegates(safeAddress, 0, 10)
+    expect(results).to.deep.equal([alice.address])
+
+    // ensure tokens from allowances are correct
+    expect(await allowanceModule.getTokens(safeAddress, alice.address)).to.deep.equal([tokenAddress])
+
+    // load an existing allowance
+    let [amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+    expect(100).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.not.equal(lastReset) // this should be set to init time
+    expect(1).to.equal(nonce)
+
+    // load an non existing allowance - bob has none
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, bob.address, tokenAddress)
+    expect(0).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.equal(lastReset)
+    expect(0).to.equal(nonce)
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(alice.address))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+
+    const transferHashData = await allowanceModule.generateTransferHash(safeAddress, tokenAddress, bob.address, 60, ZeroAddress, 0, 1)
+
+    const signature = await alice.signMessage(ethers.getBytes(transferHashData))
+
+    await allowanceModule
+      .connect(alice)
+      .executeAllowanceTransfer(
+        safe,
+        token,
+        bob.address,
+        60,
+        ZeroAddress,
+        0,
+        alice.address,
+        signature.replace(/1b$/, '1f').replace(/1c$/, '20'),
+      )
+
+    expect(940).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(alice.address))
+    expect(60).to.equal(await token.balanceOf(bob.address))
+
+    // load Alice's Allowance
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+
+    // expect the last transfer to be reflected
+    expect(100).to.equal(amount)
+    expect(60).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(lastReset > 0).to.be.true
+    expect(2).to.equal(nonce)
+
+    // remove Alice's as spender
+    await execSafeTransaction(safe, await allowanceModule.removeDelegate.populateTransaction(alice.address, true), owner)
+
+    // load Alice's Allowance after delegate removal
+    ;[amount, spent, minReset, lastReset, nonce] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+
+    // everything zeroed, except nonce
+    expect(0).to.equal(amount)
+    expect(0).to.equal(spent)
+    expect(0).to.equal(minReset)
+    expect(0).to.equal(lastReset)
+    expect(2).to.equal(nonce)
+  })
+
   it('Execute multiple ether allowance with delegate', async () => {
     const { provider } = hre.ethers
     const { safe, allowanceModule, owner, alice } = await setupTests()
@@ -182,5 +415,205 @@ describe('AllowanceModule allowanceSingle', () => {
     expect(0).to.equal(minReset)
     expect(lastReset > 0).to.be.true
     expect(3).to.equal(nonce)
+  })
+
+  it('Reverts when ether transfer fails', async () => {
+    const { provider } = hre.ethers
+    const { safe, allowanceModule, owner, alice } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+
+    // fund the safe
+    await owner.sendTransaction({
+      to: safeAddress,
+      value: OneEther,
+    })
+
+    /*
+     * Safe will contain 1 ETH
+     * Alice configured as ETH spender in Allowance
+     * Bob not configured as spender in any Allowance
+     *
+     * Alice sends to Bob
+     */
+    const bob = '0x0000000000000000000000000000000000abcdef'
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(
+      safe,
+      await allowanceModule.setAllowance.populateTransaction(
+        alice.address,
+        ZeroAddress, // zero means ether
+        ethers.parseEther('2'),
+        0,
+        0,
+      ),
+      owner,
+    )
+
+    // load an existing allowance
+    let [amount, spent, , ,] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, ZeroAddress)
+    expect(ethers.parseEther('2')).to.equal(amount)
+    expect(OneEther).to.equal(await provider.getBalance(safeAddress))
+    expect(0).to.equal(await provider.getBalance(bob))
+
+    // send 0.001 to bob using alice's allowance
+    await expect(
+      execAllowanceTransfer(allowanceModule, {
+        safe: safeAddress,
+        token: ZeroAddress,
+        to: bob,
+        amount: parseUnits('2', 'ether'),
+        spender: alice,
+      }),
+    ).to.be.revertedWith('Could not execute ether transfer')
+
+    expect(parseUnits('1', 'ether')).to.equal(await provider.getBalance(safeAddress))
+    expect(parseUnits('0', 'ether')).to.equal(await provider.getBalance(bob))
+
+    // load Alice's Allowance
+    ;[amount, spent, , ,] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, ZeroAddress)
+
+    expect(parseUnits('2', 'ether')).to.equal(amount)
+    expect(parseUnits('0', 'ether')).to.equal(spent)
+  })
+
+  it('Reverts when token transfer fails', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+    const allowanceAddress = await allowanceModule.getAddress()
+
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 2000, 0, 0), owner)
+
+    // ensure delegates are well configured
+    const { results } = await allowanceModule.getDelegates(safeAddress, 0, 10)
+    expect(results).to.deep.equal([alice.address])
+
+    // ensure tokens from allowances are correct
+    expect(await allowanceModule.getTokens(safeAddress, alice.address)).to.deep.equal([tokenAddress])
+
+    // load an existing allowance
+    let [amount, spent, , ,] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+    expect(2000).to.equal(amount)
+    expect(0).to.equal(spent)
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(alice.address))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+
+    await expect(
+      execAllowanceTransfer(allowanceModule, {
+        safe: safeAddress,
+        token: tokenAddress,
+        to: bob.address,
+        amount: 2000,
+        spender: alice,
+      }),
+    ).to.be.revertedWith('Could not execute token transfer')
+
+    expect(1000).to.equal(await token.balanceOf(safeAddress))
+    expect(0).to.equal(await token.balanceOf(alice.address))
+    expect(0).to.equal(await token.balanceOf(bob.address))
+
+    // load Alice's Allowance
+    ;[amount, spent, , ,] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, tokenAddress)
+
+    // expect the last transfer to be reflected
+    expect(2000).to.equal(amount)
+    expect(0).to.equal(spent)
+  })
+
+  it('Reverts when using smart contract signature scheme', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+    const tokenAddress = await token.getAddress()
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+    await expect(
+      allowanceModule.executeAllowanceTransfer(safe, token, bob.address, 60, ZeroAddress, 0, alice.address, `0x${'00'.repeat(65)}`),
+    ).to.be.revertedWith('Contract signatures are not supported by this module')
+  })
+
+  it('Reverts on invalid signature', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+
+    const transferHashData = await allowanceModule.generateTransferHash(safeAddress, tokenAddress, bob.address, 60, ZeroAddress, 0, 1)
+    const signature = await bob.signMessage(ethers.getBytes(transferHashData))
+
+    await expect(
+      allowanceModule.executeAllowanceTransfer(
+        safe,
+        token,
+        bob.address,
+        60,
+        ZeroAddress,
+        0,
+        alice.address,
+        signature.replace(/1b$/, '1f').replace(/1c$/, '20'),
+      ),
+    ).to.be.revertedWith('expectedDelegate == signer && delegates[address(safe)][uint48(signer)].delegate == signer')
+  })
+
+  it('Reverts on invalid signature length', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+
+    const transferHashData = await allowanceModule.generateTransferHash(safeAddress, tokenAddress, bob.address, 60, ZeroAddress, 0, 1)
+    const signature = await alice.signMessage(ethers.getBytes(transferHashData))
+
+    await expect(
+      allowanceModule.executeAllowanceTransfer(
+        safe,
+        token,
+        bob.address,
+        60,
+        ZeroAddress,
+        0,
+        alice.address,
+        `${signature.replace(/1b$/, '1f').replace(/1c$/, '20')}${'00'.repeat(65)}`,
+      ),
+    ).to.be.revertedWith('signatures.length == 65')
+  })
+
+  it('Reverts if ecrecover fails', async () => {
+    const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
+    const safeAddress = await safe.getAddress()
+    const tokenAddress = await token.getAddress()
+    // add alice as delegate
+    await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
+
+    // create an allowance for alice
+    await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
+
+    const transferHashData = await allowanceModule.generateTransferHash(safeAddress, tokenAddress, bob.address, 60, ZeroAddress, 0, 1)
+    const signature = await alice.signMessage(ethers.getBytes(transferHashData))
+
+    await expect(
+      allowanceModule.executeAllowanceTransfer(safe, token, bob.address, 60, ZeroAddress, 0, alice.address, `0x${'00'.repeat(64)}1f`),
+    ).to.be.revertedWith('owner != address(0)')
   })
 })

--- a/modules/allowances/test/allowanceSingle.spec.ts
+++ b/modules/allowances/test/allowanceSingle.spec.ts
@@ -281,7 +281,7 @@ describe('AllowanceModule allowanceSingle', () => {
 
     const transferHashData = await allowanceModule.generateTransferHash(safeAddress, tokenAddress, bob.address, 60, ZeroAddress, 0, 1)
 
-    const signature = await alice.signMessage(ethers.getBytes(transferHashData))
+    const signature = await alice.signMessage(hre.ethers.getBytes(transferHashData))
 
     await allowanceModule
       .connect(alice)
@@ -447,7 +447,7 @@ describe('AllowanceModule allowanceSingle', () => {
       await allowanceModule.setAllowance.populateTransaction(
         alice.address,
         ZeroAddress, // zero means ether
-        ethers.parseEther('2'),
+        hre.ethers.parseEther('2'),
         0,
         0,
       ),
@@ -456,7 +456,7 @@ describe('AllowanceModule allowanceSingle', () => {
 
     // load an existing allowance
     let [amount, spent, , ,] = await allowanceModule.getTokenAllowance(safeAddress, alice.address, ZeroAddress)
-    expect(ethers.parseEther('2')).to.equal(amount)
+    expect(hre.ethers.parseEther('2')).to.equal(amount)
     expect(OneEther).to.equal(await provider.getBalance(safeAddress))
     expect(0).to.equal(await provider.getBalance(bob))
 
@@ -486,7 +486,6 @@ describe('AllowanceModule allowanceSingle', () => {
 
     const safeAddress = await safe.getAddress()
     const tokenAddress = await token.getAddress()
-    const allowanceAddress = await allowanceModule.getAddress()
 
     // add alice as delegate
     await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
@@ -556,7 +555,7 @@ describe('AllowanceModule allowanceSingle', () => {
     await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
 
     const transferHashData = await allowanceModule.generateTransferHash(safeAddress, tokenAddress, bob.address, 60, ZeroAddress, 0, 1)
-    const signature = await bob.signMessage(ethers.getBytes(transferHashData))
+    const signature = await bob.signMessage(hre.ethers.getBytes(transferHashData))
 
     await expect(
       allowanceModule.executeAllowanceTransfer(
@@ -583,7 +582,7 @@ describe('AllowanceModule allowanceSingle', () => {
     await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
 
     const transferHashData = await allowanceModule.generateTransferHash(safeAddress, tokenAddress, bob.address, 60, ZeroAddress, 0, 1)
-    const signature = await alice.signMessage(ethers.getBytes(transferHashData))
+    const signature = await alice.signMessage(hre.ethers.getBytes(transferHashData))
 
     await expect(
       allowanceModule.executeAllowanceTransfer(
@@ -601,16 +600,12 @@ describe('AllowanceModule allowanceSingle', () => {
 
   it('Reverts if ecrecover fails', async () => {
     const { safe, allowanceModule, token, owner, alice, bob } = await setupTests()
-    const safeAddress = await safe.getAddress()
     const tokenAddress = await token.getAddress()
     // add alice as delegate
     await execSafeTransaction(safe, await allowanceModule.addDelegate.populateTransaction(alice.address), owner)
 
     // create an allowance for alice
     await execSafeTransaction(safe, await allowanceModule.setAllowance.populateTransaction(alice.address, tokenAddress, 100, 0, 0), owner)
-
-    const transferHashData = await allowanceModule.generateTransferHash(safeAddress, tokenAddress, bob.address, 60, ZeroAddress, 0, 1)
-    const signature = await alice.signMessage(ethers.getBytes(transferHashData))
 
     await expect(
       allowanceModule.executeAllowanceTransfer(safe, token, bob.address, 60, ZeroAddress, 0, alice.address, `0x${'00'.repeat(64)}1f`),

--- a/modules/allowances/test/test-helpers/execAllowanceTransfer.ts
+++ b/modules/allowances/test/test-helpers/execAllowanceTransfer.ts
@@ -11,12 +11,16 @@ export default async function execAllowanceTransfer(
     to,
     amount,
     spender,
+    paymentToken = ZeroAddress,
+    payment = 0,
   }: {
     safe: string
     token: string
     to: string
     amount: number | bigint
     spender: SignerWithAddress
+    paymentToken?: string
+    payment?: number | bigint
   },
 ) {
   const address = await module.getAddress()
@@ -24,20 +28,11 @@ export default async function execAllowanceTransfer(
 
   const [, , , , nonce] = await module.getTokenAllowance(safe, spender.address, token)
 
-  const { domain, types, message } = paramsToSign(address, chainId, { safe, token, to, amount }, nonce)
+  const { domain, types, message } = paramsToSign(address, chainId, { safe, token, to, amount, paymentToken, payment }, nonce)
 
   const signature = await spender.signTypedData(domain, types, message)
 
-  return module.executeAllowanceTransfer(
-    safe,
-    token,
-    to,
-    amount,
-    ZeroAddress, // paymentToken
-    0, // payment
-    spender.address,
-    signature,
-  )
+  return module.executeAllowanceTransfer(safe, token, to, amount, paymentToken, payment, spender.address, signature)
 }
 
 function paramsToSign(
@@ -48,11 +43,15 @@ function paramsToSign(
     token,
     to,
     amount,
+    paymentToken = ZeroAddress,
+    payment = 0,
   }: {
     safe: string
     token: string
     to: string
     amount: number | bigint
+    paymentToken?: string
+    payment?: number | bigint
   },
   nonce: bigint,
 ) {
@@ -74,8 +73,8 @@ function paramsToSign(
     token,
     to,
     amount,
-    paymentToken: ZeroAddress,
-    payment: 0,
+    paymentToken,
+    payment,
     nonce,
   }
 

--- a/modules/allowances/test/test-helpers/setup.ts
+++ b/modules/allowances/test/test-helpers/setup.ts
@@ -8,7 +8,7 @@ import { DeploymentsExtension } from 'hardhat-deploy/types'
 export default async function setup(deployments: DeploymentsExtension) {
   await hre.deployments.fixture()
 
-  const [owner, alice, bob] = await hre.ethers.getSigners()
+  const [owner, alice, bob, charlie] = await hre.ethers.getSigners()
 
   const safeSingleton = await deployments.get('Safe')
   const factoryDeployment = await deployments.get('SafeProxyFactory')
@@ -42,5 +42,6 @@ export default async function setup(deployments: DeploymentsExtension) {
     owner,
     alice,
     bob,
+    charlie,
   }
 }


### PR DESCRIPTION
Changes in PR:
- Add test cases to increase code coverage in `AllowanceModule` contract
- `SignatureDecoder` has in unused  internal function `recoverKey`. So, 100% code coverage for this contract is not possible.