### PR TITLE
Call correct test script for allowances

### DIFF
--- a/.github/workflows/ci_allowance.yml
+++ b/.github/workflows/ci_allowance.yml
@@ -38,7 +38,7 @@ jobs:
           cache: pnpm
       - run: |
           pnpm install
-          pnpm run --filter "@safe-global/safe-allowance-module" test:all
+          pnpm run --filter "@safe-global/safe-allowance-module" test
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The script for tests of the allowance module is called `test` not `test:all` (see https://github.com/safe-fndn/safe-modules/blob/main/modules/allowances/package.json#L14)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
