### PR TITLE
Move Candide Recovery Module Snapshot

### DIFF
--- a/examples/4337-passkeys/package.json
+++ b/examples/4337-passkeys/package.json
@@ -16,7 +16,7 @@
     "@safe-global/safe-contracts": "1.4.1-2",
     "@safe-global/safe-deployments": "^1.37.22",
     "@safe-global/safe-modules-deployments": "^2.2.4",
-    "@safe-global/safe-passkey": "workspace:^0.2.1-1",
+    "@safe-global/safe-passkey": "workspace:^0.3.0",
     "@web3modal/ethers": "^4.1.11",
     "ethers": "^6.13.4",
     "react": "^18.3.1",

--- a/modules/recovery/README.md
+++ b/modules/recovery/README.md
@@ -2,7 +2,7 @@
 
 This package contains a social recovery module compatible with the Safe smart account. It was developed by Candide Labs, and subsequently formally verified by Safe. For additional documentation, full source code, and formal verification specification, see the [Candide Labs contracts](https://github.com/candidelabs/candide-contracts) repository.
 
-The Safe team maintains a snapshot of the code that was evaluated at [5afe/CandideWalletContracts](https://github.com/5afe/CandideWalletContracts/tree/113d3c059e039e332637e8f686d9cbd505f1e738).
+The Safe team maintains a snapshot of the code that was evaluated at [safe-fndn/candide-contracts](https://github.com/safe-fndn/candide-contracts/tree/113d3c059e039e332637e8f686d9cbd505f1e738).
 
 ## External Contributions
 

--- a/modules/recovery/docs/v0.1.0/audit.md
+++ b/modules/recovery/docs/v0.1.0/audit.md
@@ -6,7 +6,7 @@ Ackee Blockchain (<https://ackeeblockchain.com/>).
 
 ## Notes
 
-The final audit was performed on commit [113d3c059e039e332637e8f686d9cbd505f1e738](https://github.com/5afe/CandideWalletContracts/tree/113d3c059e039e332637e8f686d9cbd505f1e738).
+The final audit was performed on commit [113d3c059e039e332637e8f686d9cbd505f1e738](https://github.com/safe-fndn/candide-contracts/tree/113d3c059e039e332637e8f686d9cbd505f1e738). The audit report includes references to the location where the repository snapshot was originally hosted at [`5afe/CandideWalletContracts`](https://github.com/5afe/CandideWalletContracts), but has since moved to the Safe Foundation organisation.
 
 All discovered findings were addressed.
 

--- a/modules/recovery/package.json
+++ b/modules/recovery/package.json
@@ -53,6 +53,6 @@
   "dependencies": {
     "@openzeppelin/contracts": "4.9.6",
     "@safe-global/safe-contracts": "1.4.1-2",
-    "candide-contracts": "github:5afe/CandideWalletContracts#113d3c059e039e332637e8f686d9cbd505f1e738"
+    "candide-contracts": "github:safe-fndn/candide-contracts#113d3c059e039e332637e8f686d9cbd505f1e738"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       '@safe-global/safe-passkey':
-        specifier: workspace:^0.2.1-1
+        specifier: workspace:^0.3.0
         version: link:../../modules/passkey
       '@web3modal/ethers':
         specifier: ^4.1.11
@@ -373,8 +373,8 @@ importers:
         specifier: 1.4.1-2
         version: 1.4.1-2(ethers@6.13.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       candide-contracts:
-        specifier: github:5afe/CandideWalletContracts#113d3c059e039e332637e8f686d9cbd505f1e738
-        version: https://codeload.github.com/5afe/CandideWalletContracts/tar.gz/113d3c059e039e332637e8f686d9cbd505f1e738
+        specifier: github:safe-fndn/candide-contracts#113d3c059e039e332637e8f686d9cbd505f1e738
+        version: https://codeload.github.com/safe-fndn/candide-contracts/tar.gz/113d3c059e039e332637e8f686d9cbd505f1e738
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.8
@@ -3649,8 +3649,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  candide-contracts@https://codeload.github.com/5afe/CandideWalletContracts/tar.gz/113d3c059e039e332637e8f686d9cbd505f1e738:
-    resolution: {tarball: https://codeload.github.com/5afe/CandideWalletContracts/tar.gz/113d3c059e039e332637e8f686d9cbd505f1e738}
+  candide-contracts@https://codeload.github.com/safe-fndn/candide-contracts/tar.gz/113d3c059e039e332637e8f686d9cbd505f1e738:
+    resolution: {tarball: https://codeload.github.com/safe-fndn/candide-contracts/tar.gz/113d3c059e039e332637e8f686d9cbd505f1e738}
     version: 0.1.0-alpha.0
 
   caniuse-lite@1.0.30001668:
@@ -12237,7 +12237,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  candide-contracts@https://codeload.github.com/5afe/CandideWalletContracts/tar.gz/113d3c059e039e332637e8f686d9cbd505f1e738: {}
+  candide-contracts@https://codeload.github.com/safe-fndn/candide-contracts/tar.gz/113d3c059e039e332637e8f686d9cbd505f1e738: {}
 
   caniuse-lite@1.0.30001668: {}
 


### PR DESCRIPTION
We moved the Candide recovery module snapshot to be hosted on the foundation GitHub org instead of `5afe`. This PR just updates the references to point to the new snapshot location.

